### PR TITLE
Gradle: Use ORT core's way to centrally declare dependency versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,15 +3,18 @@ import org.jetbrains.compose.compose
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+val composePluginVersion: String by project
+val detektPluginVersion: String by project
+
 val log4jVersion: String by project
 val ortVersion: String by project
 val richtextVersion: String by project
 
 plugins {
-    kotlin("jvm") version "1.6.10"
-    id("org.jetbrains.compose") version "1.0.1"
-    id("com.github.ben-manes.versions") version "0.41.0"
-    id("io.gitlab.arturbosch.detekt") version "1.19.0"
+    kotlin("jvm")
+    id("org.jetbrains.compose")
+    id("com.github.ben-manes.versions")
+    id("io.gitlab.arturbosch.detekt")
 }
 
 group = "org.ossreviewtoolkit.workbench"
@@ -47,7 +50,7 @@ repositories {
 dependencies {
     implementation(compose.desktop.currentOs)
 
-    implementation("org.jetbrains.compose.material:material-icons-extended-desktop:1.0.1")
+    implementation("org.jetbrains.compose.material:material-icons-extended-desktop:$composePluginVersion")
 
     implementation("com.github.oss-review-toolkit.ort:analyzer:$ortVersion")
     implementation("com.github.oss-review-toolkit.ort:downloader:$ortVersion")
@@ -58,7 +61,7 @@ dependencies {
     implementation("com.halilibo.compose-richtext:richtext-commonmark:$richtextVersion")
     implementation("org.apache.logging.log4j:log4j-core:$log4jVersion")
 
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.19.0")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$detektPluginVersion")
 }
 
 tasks.test {
@@ -103,7 +106,7 @@ compose.desktop {
 }
 
 detekt {
-    toolVersion = "1.19.0"
+    toolVersion = detektPluginVersion
     config = files("detekt.yml")
     buildUponDefaultConfig = true
     basePath = rootProject.projectDir.path

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,10 @@
-kotlin.code.style=official
+detektPluginVersion = 1.19.0
+composePluginVersion = 1.0.1
+kotlinPluginVersion = 1.6.10
+versionsPluginVersion = 0.41.0
 
-ortVersion=65a15f1a14
+log4jVersion = 2.17.1
+ortVersion = 65a15f1a14
+richtextVersion = 0.10.0
 
-log4jVersion=2.17.1
-richtextVersion=0.10.0
+kotlin.code.style = official

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,28 @@ pluginManagement {
         gradlePluginPortal()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
-    
+
+    resolutionStrategy {
+        eachPlugin {
+            // Work around https://github.com/gradle/gradle/issues/1697.
+            if (requested.id.namespace != "org.gradle" && requested.version == null) {
+                val versionPropertyName = if (requested.id.id.startsWith("org.jetbrains.kotlin.")) {
+                    "kotlinPluginVersion"
+                } else {
+                    val pluginName = requested.id.name.split('-').joinToString("") { it.capitalize() }.decapitalize()
+                    "${pluginName}PluginVersion"
+                }
+
+                logger.info("Checking for plugin version property '$versionPropertyName'.")
+
+                gradle.rootProject.properties[versionPropertyName]?.let { version ->
+                    logger.info("Setting '${requested.id.id}' plugin version to $version.")
+                    useVersion(version.toString())
+                } ?: logger.warn("No version specified for plugin '${requested.id.id}' and property " +
+                        "'$versionPropertyName' does not exist.")
+            }
+        }
+    }
 }
 
 rootProject.name = "ort-workbench"

--- a/src/main/kotlin/ui/Menu.kt
+++ b/src/main/kotlin/ui/Menu.kt
@@ -52,8 +52,7 @@ fun Menu(state: MenuState, resultStatus: ResultStatus) {
                 Image(
                     painter = painterResource("ort-white.png"),
                     contentDescription = "OSS Review Toolkit",
-                    contentScale = ContentScale.FillWidth,
-
+                    contentScale = ContentScale.FillWidth
                 )
             }
         }


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>