### PR TITLE
Fix dark mode colors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -127,6 +127,7 @@ compose.desktop {
 
             macOS {
                 iconFile.set(iconsRoot.resolve("icon.icns"))
+                jvmArgs("-Dapple.awt.application.appearance=system")
             }
 
             windows {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     implementation("com.github.oss-review-toolkit.ort:scanner:$ortVersion")
 
     implementation("com.halilibo.compose-richtext:richtext-commonmark:$richtextVersion")
+    implementation("com.halilibo.compose-richtext:richtext-ui-material:$richtextVersion")
     implementation("org.apache.logging.log4j:log4j-core:$log4jVersion")
 
     detektPlugins("com.github.oss-review-toolkit.ort:detekt-rules:$ortVersion")

--- a/src/main/kotlin/App.kt
+++ b/src/main/kotlin/App.kt
@@ -35,32 +35,34 @@ import org.ossreviewtoolkit.workbench.util.FileDialog
 @Composable
 fun App(state: AppState) {
     OrtWorkbenchTheme {
-        if (state.result.status == ResultStatus.FINISHED) {
-            Row(modifier = Modifier.fillMaxWidth().fillMaxHeight()) {
-                Surface(
-                    modifier = Modifier.fillMaxHeight().width(200.dp),
-                    elevation = 8.dp,
-                    color = MaterialTheme.colors.primaryVariant
-                ) {
-                    Menu(state.menu, state.result.status)
-                }
+        Surface {
+            if (state.result.status == ResultStatus.FINISHED) {
+                Row(modifier = Modifier.fillMaxWidth().fillMaxHeight()) {
+                    Surface(
+                        modifier = Modifier.fillMaxHeight().width(200.dp),
+                        elevation = 8.dp,
+                        color = MaterialTheme.colors.primaryVariant
+                    ) {
+                        Menu(state.menu, state.result.status)
+                    }
 
-                Column(
-                    modifier = Modifier.padding(5.dp).fillMaxWidth()
-                ) {
-                    Content(state)
+                    Column(
+                        modifier = Modifier.padding(5.dp).fillMaxWidth()
+                    ) {
+                        Content(state)
+                    }
                 }
+            } else {
+                LoadResult(state)
             }
-        } else {
-            LoadResult(state)
-        }
 
-        if (state.openResultDialog.isAwaiting) {
-            FileDialog(
-                title = "Load ORT result",
-                isLoad = true,
-                onResult = { state.openResultDialog.onResult(it) }
-            )
+            if (state.openResultDialog.isAwaiting) {
+                FileDialog(
+                    title = "Load ORT result",
+                    isLoad = true,
+                    onResult = { state.openResultDialog.onResult(it) }
+                )
+            }
         }
     }
 }

--- a/src/main/kotlin/ui/Content.kt
+++ b/src/main/kotlin/ui/Content.kt
@@ -2,15 +2,19 @@ package org.ossreviewtoolkit.workbench.ui
 
 import androidx.compose.runtime.Composable
 
+import com.halilibo.richtext.ui.material.SetupMaterialRichText
+
 import org.ossreviewtoolkit.workbench.state.AppState
 
 @Composable
 fun Content(state: AppState) {
-    when (state.menu.screen) {
-        MenuItem.SUMMARY -> Summary(state)
-        MenuItem.DEPENDENCIES -> Dependencies(state)
-        MenuItem.ISSUES -> Issues(state)
-        MenuItem.RULE_VIOLATIONS -> Violations(state)
-        MenuItem.VULNERABILITIES -> Vulnerabilities(state)
+    SetupMaterialRichText {
+        when (state.menu.screen) {
+            MenuItem.SUMMARY -> Summary(state)
+            MenuItem.DEPENDENCIES -> Dependencies(state)
+            MenuItem.ISSUES -> Issues(state)
+            MenuItem.RULE_VIOLATIONS -> Violations(state)
+            MenuItem.VULNERABILITIES -> Vulnerabilities(state)
+        }
     }
 }


### PR DESCRIPTION
Fixes the issue that text was not readable on multiple UI components when using MacOS's dark system setting.

Before:
![SCR-20220211-4c](https://user-images.githubusercontent.com/4022103/153511925-5c9df945-064c-4c10-8a49-d1ed64603382.png)

After:
![SCR-20220211-4u](https://user-images.githubusercontent.com/4022103/153511937-99a28dce-c0c3-4bae-a17e-09d874851f7a.png)

