### PR TITLE
Gradle: Add the SLF4J implementation for Log4j

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     implementation("com.halilibo.compose-richtext:richtext-commonmark:$richtextVersion")
     implementation("com.halilibo.compose-richtext:richtext-ui-material:$richtextVersion")
     implementation("org.apache.logging.log4j:log4j-core:$log4jVersion")
+    implementation("org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion")
 
     detektPlugins("com.github.oss-review-toolkit.ort:detekt-rules:$ortVersion")
     detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$detektPluginVersion")


### PR DESCRIPTION
This avoids the

    SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".

error and allows messages logged by libraries that use the SLF4J API to
be forwarded to the Log4j implementation.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>