### PR TITLE
OrtModel: Continue loading a file on error `FileArchiverStorage`

### DIFF
--- a/src/main/kotlin/model/OrtModel.kt
+++ b/src/main/kotlin/model/OrtModel.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.withContext
 
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
+import org.ossreviewtoolkit.model.config.FileArchiverConfiguration
 import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
 import org.ossreviewtoolkit.model.config.OrtConfiguration
 import org.ossreviewtoolkit.model.config.createFileArchiver
@@ -165,7 +166,10 @@ class OrtModel {
             val copyrightGarbage =
                 configDir.resolve(ORT_COPYRIGHT_GARBAGE_FILENAME).takeIf { it.isFile }?.readValue()
                     ?: CopyrightGarbage()
-            val fileArchiver = config.scanner.archive.createFileArchiver()
+
+            val fileArchiver = runCatching {
+                config.scanner.archive.createFileArchiver()
+            }.getOrDefault(FileArchiverConfiguration().createFileArchiver())
 
             // TODO: Let ORT provide a default location for a package configuration file.
             val packageConfigurationsDir = configDir.resolve(ORT_PACKAGE_CONFIGURATIONS_DIRNAME)


### PR DESCRIPTION
Even if a `(Postgres)FileArchiverStorage` could not be created at the
time a file is loaded (e.g. because a PostgreSQL database server cannot
be reached), continue loading the result file in order to display it.
As a fallback, create a `FileArchiverFileStorage` in that case.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>