### PR TITLE
Gradle: Start using Compose-1.2-based desktop-alpha-releases

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 detektPlugin = "1.21.0"
-composePlugin = "1.1.1"
-kotlinPlugin = "1.6.10"
+composePlugin = "1.2.0-alpha01-dev770"
+kotlinPlugin = "1.7.10"
 versionCatalogUpdatePlugin = "0.6.0"
 versionsPlugin = "0.42.0"
 

--- a/src/main/kotlin/ui/summary/Summary.kt
+++ b/src/main/kotlin/ui/summary/Summary.kt
@@ -9,8 +9,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.GridCells
-import androidx.compose.foundation.lazy.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -94,7 +94,7 @@ fun IssueStatsCard(
         title = "Issue Stats"
     ) {
         LazyVerticalGrid(
-            cells = GridCells.Fixed(count = 5),
+            columns = GridCells.Fixed(count = 5),
             modifier = Modifier.padding(vertical = 15.dp),
             verticalArrangement = Arrangement.spacedBy(5.dp)
         ) {


### PR DESCRIPTION
This allows to upgrade to Kotlin 1.7.10 in order to align with ORT's
Kotlin version. Also see [1].

[1]: https://github.com/JetBrains/compose-jb/releases

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>