### PR TITLE
Fix FileDialog double click issue

### DIFF
--- a/src/main/kotlin/ui/App.kt
+++ b/src/main/kotlin/ui/App.kt
@@ -110,13 +110,13 @@ private fun LoadResult(state: AppState, apiState: OrtApiState) {
     ) {
         Image(painter = painterResource("ort-black.png"), contentDescription = "OSS Review Toolkit")
 
-        Button(onClick = { scope.launch { state.openOrtResult() } }) {
-            Text("Load ORT Result")
-        }
-
         if (apiState in listOf(OrtApiState.LOADING_RESULT, OrtApiState.PROCESSING_RESULT)) {
             CircularProgressIndicator()
             Text("${apiState.name.replace("_", " ").titlecase()}...")
+        } else {
+            Button(onClick = { scope.launch { state.openOrtResult() } }) {
+                Text("Load ORT Result")
+            }
         }
 
         error?.let {

--- a/src/main/kotlin/ui/App.kt
+++ b/src/main/kotlin/ui/App.kt
@@ -87,6 +87,7 @@ private fun Content(state: AppState) {
             MenuItem.SUMMARY -> Summary(state.summaryViewModel, state::switchScreen) {
                 scope.launch { state.openOrtResult() }
             }
+
             MenuItem.PACKAGES -> Packages(state.packagesViewModel)
             MenuItem.DEPENDENCIES -> Dependencies(state.dependenciesViewModel)
             MenuItem.ISSUES -> Issues(state.issuesViewModel)
@@ -109,7 +110,7 @@ private fun LoadResult(state: AppState, apiState: OrtApiState) {
     ) {
         Image(painter = painterResource("ort-black.png"), contentDescription = "OSS Review Toolkit")
 
-        Button(onClick = { if (!state.openResultDialog.isAwaiting) scope.launch { state.openOrtResult() } }) {
+        Button(onClick = { scope.launch { state.openOrtResult() } }) {
             Text("Load ORT Result")
         }
 

--- a/src/main/kotlin/ui/AppState.kt
+++ b/src/main/kotlin/ui/AppState.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import org.ossreviewtoolkit.workbench.model.OrtApiState
 
 import java.nio.file.Path
 
@@ -40,9 +41,11 @@ class AppState(val ortModel: OrtModel = OrtModel.INSTANCE) {
     }
 
     suspend fun openOrtResult() {
-        val path = openResultDialog.awaitResult()
-        if (path != null) {
-            OrtModel.INSTANCE.loadOrtResult(path.toFile())
+        if (ortModel.state.value !in listOf(OrtApiState.LOADING_RESULT, OrtApiState.PROCESSING_RESULT)) {
+            val path = openResultDialog.awaitResult()
+            if (path != null) {
+                OrtModel.INSTANCE.loadOrtResult(path.toFile())
+            }
         }
     }
 }


### PR DESCRIPTION
Fix the issue that the file dialog sometimes immediately re-opens if a file is selected with a double click. See the commit messages for details.
