### PR TITLE
OrtModel: Fix reloading the same file

### DIFF
--- a/src/main/kotlin/model/OrtModel.kt
+++ b/src/main/kotlin/model/OrtModel.kt
@@ -115,6 +115,10 @@ class OrtModel {
 
                 _state.value = OrtApiState.LOADING_RESULT
 
+                // Reset the _ortResult to null before assigning a new value, otherwise no new value is emitted if the
+                // same file is loaded again.
+                _ortResult.value = null
+
                 runCatching {
                     _ortResult.value = file.readValue<OrtResult>().withResolvedScopes()
                 }.onFailure {


### PR DESCRIPTION
When reloading the same file the `_ortResult` `StateFlow` was assigned the same value as before and as a result no new value got emitted. This resulted in the UI getting stuck because the state was never updated from `LOADING_RESULT`.

Fix this by resetting `_ortResult` to `null` before assigning any new value.

Fixes #49.