### PR TITLE
Renovate: Use the correct syntax to pin / ignore dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,13 +3,8 @@
   "extends": [
     "config:base"
   ],
-  "packageRules": [
-    {
-      "matchPackageNames": [
-        "org.jetbrains.kotlin.jvm",
-        "org.yaml:snakeyaml"
-      ],
-      "rangeStrategy": "pin"
-    }
+  "ignoreDeps": [
+    "org.jetbrains.kotlin.jvm",
+    "org.yaml:snakeyaml"
   ]
 }


### PR DESCRIPTION
The "pin" range strategy actually means to "convert ranges to exact versions", see [1].

[1]: https://docs.renovatebot.com/configuration-options/#rangestrategy

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>