### PR TITLE
Upgrade to a version of ORT that configures Jackson for big YAML files

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,18 +57,6 @@ dependencies {
     detektPlugins(libs.ortDetektRules)
 }
 
-configurations.all {
-    // Do not tamper with configurations related to the detekt plugin, for some background information
-    // https://github.com/detekt/detekt/issues/2501.
-    if (!name.startsWith("detekt")) {
-        resolutionStrategy {
-            // Starting with version 1.32 the YAML file size is limited to 3 MiB, which is not configurable yet via
-            // Hoplite or Jackson.
-            force("org.yaml:snakeyaml:1.31")
-        }
-    }
-}
-
 tasks.named<DependencyUpdatesTask>("dependencyUpdates").configure {
     gradleReleaseChannel = "current"
     outputFormatter = "json"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ kotlinxCoroutines = "1.6.4"
 log4jApi = "2.19.0"
 log4jApiKotlin = "1.2.0"
 logbackImpl = "1.4.5"
-ort = "0f28f92094"
+ort = "7aa61bf96b"
 richtext = "0.15.0"
 
 [plugins]

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,6 @@
     "config:base"
   ],
   "ignoreDeps": [
-    "org.jetbrains.kotlin.jvm",
-    "org.yaml:snakeyaml"
+    "org.jetbrains.kotlin.jvm"
   ]
 }

--- a/src/main/kotlin/model/OrtApi.kt
+++ b/src/main/kotlin/model/OrtApi.kt
@@ -58,7 +58,7 @@ class OrtApi(
     fun getIssues(): List<Issue> =
         result.analyzer?.result?.collectIssues().orEmpty().toIssues(Tool.ANALYZER, resolutionProvider) +
                 result.advisor?.results?.collectIssues().orEmpty().toIssues(Tool.ADVISOR, resolutionProvider) +
-                result.scanner?.results?.collectIssues().orEmpty().toIssues(Tool.SCANNER, resolutionProvider)
+                result.scanner?.collectIssues().orEmpty().toIssues(Tool.SCANNER, resolutionProvider)
 
     fun getReferences(id: Identifier): List<DependencyReference> =
         result.getProjects().filter { it.contains(id) }.map { project ->

--- a/src/main/kotlin/model/OrtModel.kt
+++ b/src/main/kotlin/model/OrtModel.kt
@@ -25,7 +25,7 @@ import org.apache.logging.log4j.kotlin.Logging
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.config.CopyrightGarbage
 import org.ossreviewtoolkit.model.config.FileArchiverConfiguration
-import org.ossreviewtoolkit.model.config.LicenseFilenamePatterns
+import org.ossreviewtoolkit.model.config.LicenseFilePatterns
 import org.ossreviewtoolkit.model.config.OrtConfiguration
 import org.ossreviewtoolkit.model.config.createFileArchiver
 import org.ossreviewtoolkit.model.licenses.DefaultLicenseInfoProvider
@@ -167,7 +167,7 @@ class OrtModel {
             val config = ortConfigFile.takeIf { it.isFile }?.let { OrtConfiguration.load(file = it) }
                 ?: OrtConfiguration()
 
-            LicenseFilenamePatterns.configure(config.licenseFilePatterns)
+            LicenseFilePatterns.configure(config.licenseFilePatterns)
 
             val copyrightGarbage =
                 configDir.resolve(ORT_COPYRIGHT_GARBAGE_FILENAME).takeIf { it.isFile }?.readValue()
@@ -215,7 +215,7 @@ class OrtModel {
         }.onFailure {
             // TODO: Provide more context where exactly the error occurred, e.g. which config file failed to parse.
             _error.value = "Could not process ORT result: ${it.message}"
-            LicenseFilenamePatterns.configure(LicenseFilenamePatterns.DEFAULT)
+            LicenseFilePatterns.configure(LicenseFilePatterns.DEFAULT)
         }.getOrNull()
 }
 

--- a/src/main/kotlin/ui/summary/SummaryViewModel.kt
+++ b/src/main/kotlin/ui/summary/SummaryViewModel.kt
@@ -74,7 +74,7 @@ data class IssueStats(
         totalIssues = result.collectIssues().values.flatten().toStats(),
         analyzerIssues = result.analyzer?.result?.collectIssues()?.values?.flatten()?.toStats() ?: EMPTY_STATS,
         advisorIssues = result.advisor?.results?.collectIssues()?.values?.flatten()?.toStats() ?: EMPTY_STATS,
-        scannerIssues = result.scanner?.results?.collectIssues()?.values?.flatten()?.toStats() ?: EMPTY_STATS
+        scannerIssues = result.scanner?.collectIssues()?.values?.flatten()?.toStats() ?: EMPTY_STATS
     )
 }
 


### PR DESCRIPTION
This allows to get rid of sticking SnakeYAML to version 1.31. For the
complete list of commits see [1].

[1]: https://github.com/oss-review-toolkit/ort/compare/0f28f92094...7aa61bf96b

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>