### PR TITLE
Fix disabling the Renovate dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
-    "dependencyDashboard:false"
+    "config:base"
   ],
+  "dependencyDashboard": false,
   "ignoreDeps": [
     "org.jetbrains.kotlin.jvm"
   ]


### PR DESCRIPTION
See [1]. This is a fixup for c8ccdb3.

[1]: https://docs.renovatebot.com/key-concepts/dashboard/#how-to-disable-the-dashboard