### PR TITLE
Gradle: Suppress DSL_SCOPE_VIOLATION

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.compose)
     alias(libs.plugins.detekt)


### PR DESCRIPTION
This silences false-positive error messages in IntellJ [1] [2].

[1]: https://youtrack.jetbrains.com/issue/KTIJ-19369
[2]: https://github.com/gradle/gradle/issues/22797