### PR TITLE
Refactor list screens

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -6,7 +6,7 @@ complexity:
     threshold: 80
   LongParameterList:
     active: true
-    functionThreshold: 9
+    functionThreshold: 15
     constructorThreshold: 11
     ignoreDefaultParameters: true
   TooManyFunctions:

--- a/src/main/kotlin/model/FilterData.kt
+++ b/src/main/kotlin/model/FilterData.kt
@@ -1,6 +1,6 @@
 package org.ossreviewtoolkit.workbench.model
 
-data class FilterData<ITEM>(
-    val selectedItem: ITEM,
+data class FilterData<ITEM : Any>(
+    val selectedItem: ITEM?,
     val options: List<ITEM>
 )

--- a/src/main/kotlin/model/FilterData.kt
+++ b/src/main/kotlin/model/FilterData.kt
@@ -1,0 +1,6 @@
+package org.ossreviewtoolkit.workbench.model
+
+data class FilterData<ITEM>(
+    val selectedItem: ITEM,
+    val options: List<ITEM>
+)

--- a/src/main/kotlin/model/FilterData.kt
+++ b/src/main/kotlin/model/FilterData.kt
@@ -1,6 +1,6 @@
 package org.ossreviewtoolkit.workbench.model
 
 data class FilterData<ITEM : Any>(
-    val selectedItem: ITEM?,
-    val options: List<ITEM>
+    val options: List<ITEM> = emptyList(),
+    val selectedItem: ITEM? = null
 )

--- a/src/main/kotlin/ui/issues/Issues.kt
+++ b/src/main/kotlin/ui/issues/Issues.kt
@@ -16,7 +16,9 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollbarAdapter
 import androidx.compose.material.Card
 import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -26,6 +28,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 
 import java.time.Instant
 
@@ -47,9 +50,7 @@ import org.ossreviewtoolkit.workbench.util.SeverityIcon
 fun Issues(viewModel: IssuesViewModel) {
     val filteredIssues by viewModel.filteredIssues.collectAsState()
 
-    Column(
-        modifier = Modifier.padding(15.dp).fillMaxSize()
-    ) {
+    Column {
         TitleRow(viewModel)
 
         IssuesList(filteredIssues)
@@ -62,17 +63,25 @@ private fun TitleRow(viewModel: IssuesViewModel) {
     val identifiers by viewModel.identifiers.collectAsState()
     val sources by viewModel.sources.collectAsState()
 
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(10.dp)
-    ) {
-        FilterTextField(filter.text) { viewModel.updateFilter(filter.copy(text = it)) }
-        FilterSeverity(filter.severity) { viewModel.updateFilter(filter.copy(severity = it)) }
-        FilterSource(filter.source, sources) { viewModel.updateFilter(filter.copy(source = it)) }
-        FilterTool(filter.tool) { viewModel.updateFilter(filter.copy(tool = it)) }
-        FilterIdentifier(filter.identifier, identifiers) { viewModel.updateFilter(filter.copy(identifier = it)) }
-        FilterResolutionStatus(filter.resolutionStatus) { viewModel.updateFilter(filter.copy(resolutionStatus = it)) }
-    }
+    TopAppBar(
+        modifier = Modifier.zIndex(1f),
+        backgroundColor = MaterialTheme.colors.primary,
+        title = {},
+        actions = {
+            Row(modifier = Modifier.padding(vertical = 5.dp), horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                FilterTextField(filter.text) { viewModel.updateFilter(filter.copy(text = it)) }
+                FilterSeverity(filter.severity) { viewModel.updateFilter(filter.copy(severity = it)) }
+                FilterSource(filter.source, sources) { viewModel.updateFilter(filter.copy(source = it)) }
+                FilterTool(filter.tool) { viewModel.updateFilter(filter.copy(tool = it)) }
+                FilterIdentifier(filter.identifier, identifiers) {
+                    viewModel.updateFilter(filter.copy(identifier = it))
+                }
+                FilterResolutionStatus(filter.resolutionStatus) {
+                    viewModel.updateFilter(filter.copy(resolutionStatus = it))
+                }
+            }
+        }
+    )
 }
 
 @Composable
@@ -161,13 +170,13 @@ private fun FilterResolutionStatus(
 @Composable
 fun IssuesList(issues: List<Issue>) {
     if (issues.isEmpty()) {
-        Text("No issues found.", modifier = Modifier.padding(top = 15.dp))
+        Text("No issues found.", modifier = Modifier.padding(15.dp))
     } else {
-        Box(modifier = Modifier.fillMaxSize().padding(top = 15.dp)) {
+        Box(modifier = Modifier.fillMaxSize()) {
             val listState = rememberLazyListState()
 
             LazyColumn(
-                contentPadding = PaddingValues(vertical = 15.dp),
+                contentPadding = PaddingValues(15.dp),
                 verticalArrangement = Arrangement.spacedBy(10.dp),
                 state = listState
             ) {

--- a/src/main/kotlin/ui/issues/Issues.kt
+++ b/src/main/kotlin/ui/issues/Issues.kt
@@ -86,7 +86,7 @@ private fun TitleRow(
                     data = state.severityFilter,
                     label = "Severity",
                     onFilterChange = onUpdateSeverityFilter,
-                    convert = { it?.name?.titlecase() ?: "" }
+                    convert = { it.name.titlecase() }
                 )
 
                 FilterButton(data = state.sourceFilter, label = "Source", onFilterChange = onUpdateSourceFilter)
@@ -95,21 +95,21 @@ private fun TitleRow(
                     data = state.toolFilter,
                     label = "Tool",
                     onFilterChange = onUpdateToolFilter,
-                    convert = { it?.name?.titlecase() ?: "" }
+                    convert = { it.name.titlecase() }
                 )
 
                 FilterButton(
                     data = state.identifierFilter,
                     label = "Package",
                     onFilterChange = onUpdateIdentifierFilter,
-                    convert = { it?.toCoordinates() ?: "" }
+                    convert = { it.toCoordinates() }
                 )
 
                 FilterButton(
                     data = state.resolutionStatusFilter,
                     label = "Resolution",
                     onFilterChange = onUpdateResolutionStatusFilter,
-                    convert = { it?.name?.titlecase() ?: "" }
+                    convert = { it.name.titlecase() }
                 )
             }
         }

--- a/src/main/kotlin/ui/issues/Issues.kt
+++ b/src/main/kotlin/ui/issues/Issues.kt
@@ -69,7 +69,7 @@ private fun TitleRow(
     state: IssuesState,
     onUpdateTextFilter: (text: String) -> Unit,
     onUpdateIdentifierFilter: (identifier: Identifier?) -> Unit,
-    onUpdateResolutionStatusFilter: (status: ResolutionStatus) -> Unit,
+    onUpdateResolutionStatusFilter: (status: ResolutionStatus?) -> Unit,
     onUpdateSeverityFilter: (severity: Severity?) -> Unit,
     onUpdateSourceFilter: (source: String?) -> Unit,
     onUpdateToolFilter: (tool: Tool?) -> Unit
@@ -109,7 +109,7 @@ private fun TitleRow(
                     data = state.resolutionStatusFilter,
                     label = "Resolution",
                     onFilterChange = onUpdateResolutionStatusFilter,
-                    convert = { it.name.titlecase() }
+                    convert = { it?.name?.titlecase() ?: "" }
                 )
             }
         }

--- a/src/main/kotlin/ui/issues/IssuesState.kt
+++ b/src/main/kotlin/ui/issues/IssuesState.kt
@@ -11,7 +11,7 @@ data class IssuesState(
     val issues: List<Issue>,
     val textFilter: String,
     val identifierFilter: FilterData<Identifier?>,
-    val resolutionStatusFilter: FilterData<ResolutionStatus>,
+    val resolutionStatusFilter: FilterData<ResolutionStatus?>,
     val severityFilter: FilterData<Severity?>,
     val sourceFilter: FilterData<String?>,
     val toolFilter: FilterData<Tool?>
@@ -21,7 +21,7 @@ data class IssuesState(
             issues = emptyList(),
             textFilter = "",
             identifierFilter = FilterData(null, emptyList()),
-            resolutionStatusFilter = FilterData(ResolutionStatus.ALL, emptyList()),
+            resolutionStatusFilter = FilterData(null, emptyList()),
             severityFilter = FilterData(null, emptyList()),
             sourceFilter = FilterData(null, emptyList()),
             toolFilter = FilterData(null, emptyList()),

--- a/src/main/kotlin/ui/issues/IssuesState.kt
+++ b/src/main/kotlin/ui/issues/IssuesState.kt
@@ -10,11 +10,11 @@ import org.ossreviewtoolkit.workbench.util.ResolutionStatus
 data class IssuesState(
     val issues: List<Issue>,
     val textFilter: String,
-    val identifierFilter: FilterData<Identifier?>,
-    val resolutionStatusFilter: FilterData<ResolutionStatus?>,
-    val severityFilter: FilterData<Severity?>,
-    val sourceFilter: FilterData<String?>,
-    val toolFilter: FilterData<Tool?>
+    val identifierFilter: FilterData<Identifier>,
+    val resolutionStatusFilter: FilterData<ResolutionStatus>,
+    val severityFilter: FilterData<Severity>,
+    val sourceFilter: FilterData<String>,
+    val toolFilter: FilterData<Tool>
 ) {
     companion object {
         val INITIAL = IssuesState(

--- a/src/main/kotlin/ui/issues/IssuesState.kt
+++ b/src/main/kotlin/ui/issues/IssuesState.kt
@@ -1,0 +1,30 @@
+package org.ossreviewtoolkit.workbench.ui.issues
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.Severity
+import org.ossreviewtoolkit.workbench.model.FilterData
+import org.ossreviewtoolkit.workbench.model.Issue
+import org.ossreviewtoolkit.workbench.model.Tool
+import org.ossreviewtoolkit.workbench.util.ResolutionStatus
+
+data class IssuesState(
+    val issues: List<Issue>,
+    val textFilter: String,
+    val identifierFilter: FilterData<Identifier?>,
+    val resolutionStatusFilter: FilterData<ResolutionStatus>,
+    val severityFilter: FilterData<Severity?>,
+    val sourceFilter: FilterData<String?>,
+    val toolFilter: FilterData<Tool?>
+) {
+    companion object {
+        val INITIAL = IssuesState(
+            issues = emptyList(),
+            textFilter = "",
+            identifierFilter = FilterData(null, emptyList()),
+            resolutionStatusFilter = FilterData(ResolutionStatus.ALL, emptyList()),
+            severityFilter = FilterData(null, emptyList()),
+            sourceFilter = FilterData(null, emptyList()),
+            toolFilter = FilterData(null, emptyList()),
+        )
+    }
+}

--- a/src/main/kotlin/ui/issues/IssuesState.kt
+++ b/src/main/kotlin/ui/issues/IssuesState.kt
@@ -20,11 +20,11 @@ data class IssuesState(
         val INITIAL = IssuesState(
             issues = emptyList(),
             textFilter = "",
-            identifierFilter = FilterData(null, emptyList()),
-            resolutionStatusFilter = FilterData(null, emptyList()),
-            severityFilter = FilterData(null, emptyList()),
-            sourceFilter = FilterData(null, emptyList()),
-            toolFilter = FilterData(null, emptyList()),
+            identifierFilter = FilterData(),
+            resolutionStatusFilter = FilterData(),
+            severityFilter = FilterData(),
+            sourceFilter = FilterData(),
+            toolFilter = FilterData()
         )
     }
 }

--- a/src/main/kotlin/ui/issues/IssuesViewModel.kt
+++ b/src/main/kotlin/ui/issues/IssuesViewModel.kt
@@ -54,26 +54,11 @@ class IssuesViewModel(private val ortModel: OrtModel = OrtModel.INSTANCE) {
         _state.value = IssuesState(
             issues = issues,
             textFilter = "",
-            identifierFilter = FilterData(
-                selectedItem = null,
-                options = issues.mapTo(sortedSetOf()) { it.id }.toList()
-            ),
-            resolutionStatusFilter = FilterData(
-                selectedItem = null,
-                options = ResolutionStatus.values().toList()
-            ),
-            severityFilter = FilterData(
-                selectedItem = null,
-                options = Severity.values().toList()
-            ),
-            sourceFilter = FilterData(
-                selectedItem = null,
-                options = issues.mapTo(sortedSetOf()) { it.source }.toList()
-            ),
-            toolFilter = FilterData(
-                selectedItem = null,
-                options = Tool.values().toList()
-            )
+            identifierFilter = FilterData(issues.mapTo(sortedSetOf()) { it.id }.toList()),
+            resolutionStatusFilter = FilterData(ResolutionStatus.values().toList()),
+            severityFilter = FilterData(Severity.values().toList()),
+            sourceFilter = FilterData(issues.mapTo(sortedSetOf()) { it.source }.toList()),
+            toolFilter = FilterData(Tool.values().toList())
         )
     }
 

--- a/src/main/kotlin/ui/issues/IssuesViewModel.kt
+++ b/src/main/kotlin/ui/issues/IssuesViewModel.kt
@@ -56,23 +56,23 @@ class IssuesViewModel(private val ortModel: OrtModel = OrtModel.INSTANCE) {
             textFilter = "",
             identifierFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + issues.mapTo(sortedSetOf()) { it.id }.toList()
+                options = issues.mapTo(sortedSetOf()) { it.id }.toList()
             ),
             resolutionStatusFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + ResolutionStatus.values().toList()
+                options = ResolutionStatus.values().toList()
             ),
             severityFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + Severity.values().toList()
+                options = Severity.values().toList()
             ),
             sourceFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + issues.mapTo(sortedSetOf()) { it.source }.toList()
+                options = issues.mapTo(sortedSetOf()) { it.source }.toList()
             ),
             toolFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + Tool.values().toList()
+                options = Tool.values().toList()
             )
         )
     }

--- a/src/main/kotlin/ui/issues/IssuesViewModel.kt
+++ b/src/main/kotlin/ui/issues/IssuesViewModel.kt
@@ -59,8 +59,8 @@ class IssuesViewModel(private val ortModel: OrtModel = OrtModel.INSTANCE) {
                 options = listOf(null) + issues.mapTo(sortedSetOf()) { it.id }.toList()
             ),
             resolutionStatusFilter = FilterData(
-                selectedItem = ResolutionStatus.ALL,
-                options = ResolutionStatus.values().toList()
+                selectedItem = null,
+                options = listOf(null) + ResolutionStatus.values().toList()
             ),
             severityFilter = FilterData(
                 selectedItem = null,
@@ -85,7 +85,7 @@ class IssuesViewModel(private val ortModel: OrtModel = OrtModel.INSTANCE) {
         filter.value = filter.value.copy(identifier = identifier)
     }
 
-    fun updateResolutionStatusFilter(resolutionStatus: ResolutionStatus) {
+    fun updateResolutionStatusFilter(resolutionStatus: ResolutionStatus?) {
         filter.value = filter.value.copy(resolutionStatus = resolutionStatus)
     }
 
@@ -104,7 +104,7 @@ class IssuesViewModel(private val ortModel: OrtModel = OrtModel.INSTANCE) {
 
 data class IssuesFilter(
     val identifier: Identifier? = null,
-    val resolutionStatus: ResolutionStatus = ResolutionStatus.ALL,
+    val resolutionStatus: ResolutionStatus? = null,
     val severity: Severity? = null,
     val source: String? = null,
     val text: String = "",

--- a/src/main/kotlin/ui/packages/Packages.kt
+++ b/src/main/kotlin/ui/packages/Packages.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.Divider
 import androidx.compose.material.LocalContentAlpha
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
@@ -29,6 +30,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.licenses.LicenseView
@@ -44,9 +46,7 @@ import org.ossreviewtoolkit.workbench.util.enumcase
 fun Packages(viewModel: PackagesViewModel) {
     val filteredPackages by viewModel.filteredPackages.collectAsState()
 
-    Column(
-        modifier = Modifier.padding(15.dp).fillMaxSize()
-    ) {
+    Column {
         TitleRow(viewModel)
 
         PackagesList(filteredPackages)
@@ -62,22 +62,20 @@ private fun TitleRow(viewModel: PackagesViewModel) {
     val scopes by viewModel.scopes.collectAsState()
     val licenses by viewModel.licenses.collectAsState()
 
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(10.dp)
-    ) {
-        FilterTextField(filter.text) { viewModel.updateFilter(filter.copy(text = it)) }
-
-        Column {
-            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+    TopAppBar(
+        modifier = Modifier.zIndex(1f),
+        backgroundColor = MaterialTheme.colors.primary,
+        title = {},
+        actions = {
+            Row(modifier = Modifier.padding(vertical = 5.dp), horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                FilterTextField(filter.text) { viewModel.updateFilter(filter.copy(text = it)) }
                 FilterType(filter.type, types) { viewModel.updateFilter(filter.copy(type = it)) }
-                FilterNamespace(filter.namespace, namespaces) { viewModel.updateFilter(filter.copy(namespace = it)) }
+                FilterNamespace(filter.namespace, namespaces) {
+                    viewModel.updateFilter(filter.copy(namespace = it))
+                }
                 FilterProject(filter.project, projects) { viewModel.updateFilter(filter.copy(project = it)) }
                 FilterScope(filter.scope, scopes) { viewModel.updateFilter(filter.copy(scope = it)) }
                 FilterLicense(filter.license, licenses) { viewModel.updateFilter(filter.copy(license = it)) }
-            }
-
-            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                 FilterIssueStatus(filter.issueStatus) { viewModel.updateFilter(filter.copy(issueStatus = it)) }
                 FilterViolationStatus(filter.violationStatus) {
                     viewModel.updateFilter(filter.copy(violationStatus = it))
@@ -90,7 +88,7 @@ private fun TitleRow(viewModel: PackagesViewModel) {
                 }
             }
         }
-    }
+    )
 }
 
 @Composable
@@ -233,13 +231,13 @@ private fun FilterExclusionStatus(
 @Composable
 fun PackagesList(packages: List<PackageInfo>) {
     if (packages.isEmpty()) {
-        Text("No packages found.", modifier = Modifier.padding(top = 15.dp))
+        Text("No packages found.", modifier = Modifier.padding(15.dp))
     } else {
-        Box(modifier = Modifier.fillMaxSize().padding(top = 15.dp)) {
+        Box(modifier = Modifier.fillMaxSize()) {
             val listState = rememberLazyListState()
 
             LazyColumn(
-                contentPadding = PaddingValues(vertical = 15.dp),
+                contentPadding = PaddingValues(15.dp),
                 verticalArrangement = Arrangement.spacedBy(10.dp),
                 state = listState
             ) {

--- a/src/main/kotlin/ui/packages/Packages.kt
+++ b/src/main/kotlin/ui/packages/Packages.kt
@@ -97,7 +97,7 @@ private fun TitleRow(
                     data = state.projectFilter,
                     label = "Project",
                     onFilterChange = onUpdateProjectFilter,
-                    convert = { it?.toCoordinates() ?: "" }
+                    convert = { it.toCoordinates() }
                 )
 
                 FilterButton(data = state.scopeFilter, label = "Scope", onFilterChange = onUpdateScopeFilter)
@@ -108,28 +108,28 @@ private fun TitleRow(
                     data = state.issueStatusFilter,
                     label = "Issues",
                     onFilterChange = onUpdateIssueStatusFilter,
-                    convert = { it?.name?.titlecase() ?: "" }
+                    convert = { it.name.titlecase() }
                 )
 
                 FilterButton(
                     data = state.violationStatusFilter,
                     label = "Violations",
                     onFilterChange = onUpdateViolationStatusFilter,
-                    convert = { it?.name?.titlecase() ?: "" }
+                    convert = { it.name.titlecase() }
                 )
 
                 FilterButton(
                     data = state.vulnerabilityStatusFilter,
                     label = "Vulnerabilities",
                     onFilterChange = onUpdateVulnerabilityStatusFilter,
-                    convert = { it?.name?.titlecase() ?: "" }
+                    convert = { it.name.titlecase() }
                 )
 
                 FilterButton(
                     data = state.exclusionStatusFilter,
                     label = "Excluded",
                     onFilterChange = onUpdateExclusionStatusFilter,
-                    convert = { it?.name?.titlecase() ?: "" }
+                    convert = { it.name.titlecase() }
                 )
             }
         }

--- a/src/main/kotlin/ui/packages/Packages.kt
+++ b/src/main/kotlin/ui/packages/Packages.kt
@@ -67,15 +67,15 @@ fun Packages(viewModel: PackagesViewModel) {
 private fun TitleRow(
     state: PackagesState,
     onUpdateTextFilter: (text: String) -> Unit,
-    onUpdateExclusionStatusFilter: (exclusionStatus: ExclusionStatus) -> Unit,
-    onUpdateIssueStatusFilter: (issueStatus: IssueStatus) -> Unit,
+    onUpdateExclusionStatusFilter: (exclusionStatus: ExclusionStatus?) -> Unit,
+    onUpdateIssueStatusFilter: (issueStatus: IssueStatus?) -> Unit,
     onUpdateLicenseFilter: (license: SpdxSingleLicenseExpression?) -> Unit,
     onUpdateNamespaceFilter: (namespace: String?) -> Unit,
     onUpdateProjectFilter: (project: Identifier?) -> Unit,
     onUpdateScopeFilter: (scope: String?) -> Unit,
     onUpdateTypeFilter: (type: String?) -> Unit,
-    onUpdateViolationStatusFilter: (violationStatus: ViolationStatus) -> Unit,
-    onUpdateVulnerabilityStatusFilter: (vulnerabilityStatus: VulnerabilityStatus) -> Unit
+    onUpdateViolationStatusFilter: (violationStatus: ViolationStatus?) -> Unit,
+    onUpdateVulnerabilityStatusFilter: (vulnerabilityStatus: VulnerabilityStatus?) -> Unit
 ) {
     TopAppBar(
         modifier = Modifier.zIndex(1f),
@@ -108,28 +108,28 @@ private fun TitleRow(
                     data = state.issueStatusFilter,
                     label = "Issues",
                     onFilterChange = onUpdateIssueStatusFilter,
-                    convert = { it.name.titlecase() }
+                    convert = { it?.name?.titlecase() ?: "" }
                 )
 
                 FilterButton(
                     data = state.violationStatusFilter,
                     label = "Violations",
                     onFilterChange = onUpdateViolationStatusFilter,
-                    convert = { it.name.titlecase() }
+                    convert = { it?.name?.titlecase() ?: "" }
                 )
 
                 FilterButton(
                     data = state.vulnerabilityStatusFilter,
                     label = "Vulnerabilities",
                     onFilterChange = onUpdateVulnerabilityStatusFilter,
-                    convert = { it.name.titlecase() }
+                    convert = { it?.name?.titlecase() ?: "" }
                 )
 
                 FilterButton(
                     data = state.exclusionStatusFilter,
                     label = "Excluded",
                     onFilterChange = onUpdateExclusionStatusFilter,
-                    convert = { it.name.titlecase() }
+                    convert = { it?.name?.titlecase() ?: "" }
                 )
             }
         }

--- a/src/main/kotlin/ui/packages/PackagesState.kt
+++ b/src/main/kotlin/ui/packages/PackagesState.kt
@@ -7,29 +7,29 @@ import org.ossreviewtoolkit.workbench.model.FilterData
 data class PackagesState(
     val packages: List<PackageInfo>,
     val textFilter: String,
-    val exclusionStatusFilter: FilterData<ExclusionStatus>,
-    val issueStatusFilter: FilterData<IssueStatus>,
+    val exclusionStatusFilter: FilterData<ExclusionStatus?>,
+    val issueStatusFilter: FilterData<IssueStatus?>,
     val licenseFilter: FilterData<SpdxSingleLicenseExpression?>,
     val namespaceFilter: FilterData<String?>,
     val projectFilter: FilterData<Identifier?>,
     val scopeFilter: FilterData<String?>,
     val typeFilter: FilterData<String?>,
-    val violationStatusFilter: FilterData<ViolationStatus>,
-    val vulnerabilityStatusFilter: FilterData<VulnerabilityStatus>
+    val violationStatusFilter: FilterData<ViolationStatus?>,
+    val vulnerabilityStatusFilter: FilterData<VulnerabilityStatus?>
 ) {
     companion object {
         val INITIAL = PackagesState(
             packages = emptyList(),
             textFilter = "",
-            exclusionStatusFilter = FilterData(ExclusionStatus.ALL, emptyList()),
-            issueStatusFilter = FilterData(IssueStatus.ALL, emptyList()),
+            exclusionStatusFilter = FilterData(null, emptyList()),
+            issueStatusFilter = FilterData(null, emptyList()),
             licenseFilter = FilterData(null, emptyList()),
             namespaceFilter = FilterData(null, emptyList()),
             projectFilter = FilterData(null, emptyList()),
             scopeFilter = FilterData(null, emptyList()),
             typeFilter = FilterData(null, emptyList()),
-            violationStatusFilter = FilterData(ViolationStatus.ALL, emptyList()),
-            vulnerabilityStatusFilter = FilterData(VulnerabilityStatus.ALL, emptyList()),
+            violationStatusFilter = FilterData(null, emptyList()),
+            vulnerabilityStatusFilter = FilterData(null, emptyList()),
         )
     }
 }

--- a/src/main/kotlin/ui/packages/PackagesState.kt
+++ b/src/main/kotlin/ui/packages/PackagesState.kt
@@ -21,15 +21,15 @@ data class PackagesState(
         val INITIAL = PackagesState(
             packages = emptyList(),
             textFilter = "",
-            exclusionStatusFilter = FilterData(null, emptyList()),
-            issueStatusFilter = FilterData(null, emptyList()),
-            licenseFilter = FilterData(null, emptyList()),
-            namespaceFilter = FilterData(null, emptyList()),
-            projectFilter = FilterData(null, emptyList()),
-            scopeFilter = FilterData(null, emptyList()),
-            typeFilter = FilterData(null, emptyList()),
-            violationStatusFilter = FilterData(null, emptyList()),
-            vulnerabilityStatusFilter = FilterData(null, emptyList()),
+            exclusionStatusFilter = FilterData(),
+            issueStatusFilter = FilterData(),
+            licenseFilter = FilterData(),
+            namespaceFilter = FilterData(),
+            projectFilter = FilterData(),
+            scopeFilter = FilterData(),
+            typeFilter = FilterData(),
+            violationStatusFilter = FilterData(),
+            vulnerabilityStatusFilter = FilterData()
         )
     }
 }

--- a/src/main/kotlin/ui/packages/PackagesState.kt
+++ b/src/main/kotlin/ui/packages/PackagesState.kt
@@ -1,0 +1,35 @@
+package org.ossreviewtoolkit.workbench.ui.packages
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
+import org.ossreviewtoolkit.workbench.model.FilterData
+
+data class PackagesState(
+    val packages: List<PackageInfo>,
+    val textFilter: String,
+    val exclusionStatusFilter: FilterData<ExclusionStatus>,
+    val issueStatusFilter: FilterData<IssueStatus>,
+    val licenseFilter: FilterData<SpdxSingleLicenseExpression?>,
+    val namespaceFilter: FilterData<String?>,
+    val projectFilter: FilterData<Identifier?>,
+    val scopeFilter: FilterData<String?>,
+    val typeFilter: FilterData<String?>,
+    val violationStatusFilter: FilterData<ViolationStatus>,
+    val vulnerabilityStatusFilter: FilterData<VulnerabilityStatus>
+) {
+    companion object {
+        val INITIAL = PackagesState(
+            packages = emptyList(),
+            textFilter = "",
+            exclusionStatusFilter = FilterData(ExclusionStatus.ALL, emptyList()),
+            issueStatusFilter = FilterData(IssueStatus.ALL, emptyList()),
+            licenseFilter = FilterData(null, emptyList()),
+            namespaceFilter = FilterData(null, emptyList()),
+            projectFilter = FilterData(null, emptyList()),
+            scopeFilter = FilterData(null, emptyList()),
+            typeFilter = FilterData(null, emptyList()),
+            violationStatusFilter = FilterData(ViolationStatus.ALL, emptyList()),
+            vulnerabilityStatusFilter = FilterData(VulnerabilityStatus.ALL, emptyList()),
+        )
+    }
+}

--- a/src/main/kotlin/ui/packages/PackagesState.kt
+++ b/src/main/kotlin/ui/packages/PackagesState.kt
@@ -7,15 +7,15 @@ import org.ossreviewtoolkit.workbench.model.FilterData
 data class PackagesState(
     val packages: List<PackageInfo>,
     val textFilter: String,
-    val exclusionStatusFilter: FilterData<ExclusionStatus?>,
-    val issueStatusFilter: FilterData<IssueStatus?>,
-    val licenseFilter: FilterData<SpdxSingleLicenseExpression?>,
-    val namespaceFilter: FilterData<String?>,
-    val projectFilter: FilterData<Identifier?>,
-    val scopeFilter: FilterData<String?>,
-    val typeFilter: FilterData<String?>,
-    val violationStatusFilter: FilterData<ViolationStatus?>,
-    val vulnerabilityStatusFilter: FilterData<VulnerabilityStatus?>
+    val exclusionStatusFilter: FilterData<ExclusionStatus>,
+    val issueStatusFilter: FilterData<IssueStatus>,
+    val licenseFilter: FilterData<SpdxSingleLicenseExpression>,
+    val namespaceFilter: FilterData<String>,
+    val projectFilter: FilterData<Identifier>,
+    val scopeFilter: FilterData<String>,
+    val typeFilter: FilterData<String>,
+    val violationStatusFilter: FilterData<ViolationStatus>,
+    val vulnerabilityStatusFilter: FilterData<VulnerabilityStatus>
 ) {
     companion object {
         val INITIAL = PackagesState(

--- a/src/main/kotlin/ui/packages/PackagesViewModel.kt
+++ b/src/main/kotlin/ui/packages/PackagesViewModel.kt
@@ -98,46 +98,23 @@ class PackagesViewModel(private val ortModel: OrtModel = OrtModel.INSTANCE) {
         _state.value = PackagesState(
             packages = packages,
             textFilter = "",
-            exclusionStatusFilter = FilterData(
-                selectedItem = null,
-                options = ExclusionStatus.values().toList()
-            ),
-            issueStatusFilter = FilterData(
-                selectedItem = null,
-                options = IssueStatus.values().toList()
-            ),
+            exclusionStatusFilter = FilterData(ExclusionStatus.values().toList()),
+            issueStatusFilter = FilterData(IssueStatus.values().toList()),
             licenseFilter = FilterData(
-                selectedItem = null,
-                options = packages.flatMapTo(sortedSetOf(SpdxExpressionStringComparator())) {
+                packages.flatMapTo(sortedSetOf(SpdxExpressionStringComparator())) {
                     it.resolvedLicenseInfo.licenses.map { it.license }
                 }.toList()
             ),
-            namespaceFilter = FilterData(
-                selectedItem = null,
-                options = packages.mapTo(sortedSetOf()) { it.metadata.id.namespace }.toList()
-            ),
-            projectFilter = FilterData(
-                selectedItem = null,
-                options = packages.flatMapTo(sortedSetOf()) { it.references.map { it.project } }.toList()
-            ),
+            namespaceFilter = FilterData(packages.mapTo(sortedSetOf()) { it.metadata.id.namespace }.toList()),
+            projectFilter = FilterData(packages.flatMapTo(sortedSetOf()) { it.references.map { it.project } }.toList()),
             scopeFilter = FilterData(
-                selectedItem = null,
-                options = packages.flatMapTo(sortedSetOf()) {
+                packages.flatMapTo(sortedSetOf()) {
                     it.references.flatMap { it.scopes.map { it.scope } }
                 }.toList()
             ),
-            typeFilter = FilterData(
-                selectedItem = null,
-                options = packages.mapTo(sortedSetOf()) { it.metadata.id.type }.toList()
-            ),
-            violationStatusFilter = FilterData(
-                selectedItem = null,
-                options = ViolationStatus.values().toList()
-            ),
-            vulnerabilityStatusFilter = FilterData(
-                selectedItem = null,
-                options = VulnerabilityStatus.values().toList()
-            )
+            typeFilter = FilterData(packages.mapTo(sortedSetOf()) { it.metadata.id.type }.toList()),
+            violationStatusFilter = FilterData(ViolationStatus.values().toList()),
+            vulnerabilityStatusFilter = FilterData(VulnerabilityStatus.values().toList())
         )
     }
 

--- a/src/main/kotlin/ui/packages/PackagesViewModel.kt
+++ b/src/main/kotlin/ui/packages/PackagesViewModel.kt
@@ -100,43 +100,43 @@ class PackagesViewModel(private val ortModel: OrtModel = OrtModel.INSTANCE) {
             textFilter = "",
             exclusionStatusFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + ExclusionStatus.values().toList()
+                options = ExclusionStatus.values().toList()
             ),
             issueStatusFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + IssueStatus.values().toList()
+                options = IssueStatus.values().toList()
             ),
             licenseFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + packages.flatMapTo(sortedSetOf(SpdxExpressionStringComparator())) {
+                options = packages.flatMapTo(sortedSetOf(SpdxExpressionStringComparator())) {
                     it.resolvedLicenseInfo.licenses.map { it.license }
                 }.toList()
             ),
             namespaceFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + packages.mapTo(sortedSetOf()) { it.metadata.id.namespace }.toList()
+                options = packages.mapTo(sortedSetOf()) { it.metadata.id.namespace }.toList()
             ),
             projectFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + packages.flatMapTo(sortedSetOf()) { it.references.map { it.project } }.toList()
+                options = packages.flatMapTo(sortedSetOf()) { it.references.map { it.project } }.toList()
             ),
             scopeFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + packages.flatMapTo(sortedSetOf()) {
+                options = packages.flatMapTo(sortedSetOf()) {
                     it.references.flatMap { it.scopes.map { it.scope } }
                 }.toList()
             ),
             typeFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + packages.mapTo(sortedSetOf()) { it.metadata.id.type }.toList()
+                options = packages.mapTo(sortedSetOf()) { it.metadata.id.type }.toList()
             ),
             violationStatusFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + ViolationStatus.values().toList()
+                options = ViolationStatus.values().toList()
             ),
             vulnerabilityStatusFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + VulnerabilityStatus.values().toList()
+                options = VulnerabilityStatus.values().toList()
             )
         )
     }

--- a/src/main/kotlin/ui/packages/PackagesViewModel.kt
+++ b/src/main/kotlin/ui/packages/PackagesViewModel.kt
@@ -99,12 +99,12 @@ class PackagesViewModel(private val ortModel: OrtModel = OrtModel.INSTANCE) {
             packages = packages,
             textFilter = "",
             exclusionStatusFilter = FilterData(
-                selectedItem = ExclusionStatus.ALL,
-                options = ExclusionStatus.values().toList()
+                selectedItem = null,
+                options = listOf(null) + ExclusionStatus.values().toList()
             ),
             issueStatusFilter = FilterData(
-                selectedItem = IssueStatus.ALL,
-                options = IssueStatus.values().toList()
+                selectedItem = null,
+                options = listOf(null) + IssueStatus.values().toList()
             ),
             licenseFilter = FilterData(
                 selectedItem = null,
@@ -131,12 +131,12 @@ class PackagesViewModel(private val ortModel: OrtModel = OrtModel.INSTANCE) {
                 options = listOf(null) + packages.mapTo(sortedSetOf()) { it.metadata.id.type }.toList()
             ),
             violationStatusFilter = FilterData(
-                selectedItem = ViolationStatus.ALL,
-                options = ViolationStatus.values().toList()
+                selectedItem = null,
+                options = listOf(null) + ViolationStatus.values().toList()
             ),
             vulnerabilityStatusFilter = FilterData(
-                selectedItem = VulnerabilityStatus.ALL,
-                options = VulnerabilityStatus.values().toList()
+                selectedItem = null,
+                options = listOf(null) + VulnerabilityStatus.values().toList()
             )
         )
     }
@@ -145,11 +145,11 @@ class PackagesViewModel(private val ortModel: OrtModel = OrtModel.INSTANCE) {
         filter.value = filter.value.copy(text = text)
     }
 
-    fun updateExclusionStatusFilter(exclusionStatus: ExclusionStatus) {
+    fun updateExclusionStatusFilter(exclusionStatus: ExclusionStatus?) {
         filter.value = filter.value.copy(exclusionStatus = exclusionStatus)
     }
 
-    fun updateIssueStatusFilter(issueStatus: IssueStatus) {
+    fun updateIssueStatusFilter(issueStatus: IssueStatus?) {
         filter.value = filter.value.copy(issueStatus = issueStatus)
     }
 
@@ -173,11 +173,11 @@ class PackagesViewModel(private val ortModel: OrtModel = OrtModel.INSTANCE) {
         filter.value = filter.value.copy(type = type)
     }
 
-    fun updateViolationStatusFilter(violationStatus: ViolationStatus) {
+    fun updateViolationStatusFilter(violationStatus: ViolationStatus?) {
         filter.value = filter.value.copy(violationStatus = violationStatus)
     }
 
-    fun updateVulnerabilityStatusFilter(vulnerabilityStatus: VulnerabilityStatus) {
+    fun updateVulnerabilityStatusFilter(vulnerabilityStatus: VulnerabilityStatus?) {
         filter.value = filter.value.copy(vulnerabilityStatus = vulnerabilityStatus)
     }
 }
@@ -207,10 +207,10 @@ data class PackagesFilter(
     val project: Identifier? = null,
     val scope: String? = null,
     val license: SpdxSingleLicenseExpression? = null,
-    val issueStatus: IssueStatus = IssueStatus.ALL,
-    val violationStatus: ViolationStatus = ViolationStatus.ALL,
-    val vulnerabilityStatus: VulnerabilityStatus = VulnerabilityStatus.ALL,
-    val exclusionStatus: ExclusionStatus = ExclusionStatus.ALL
+    val issueStatus: IssueStatus? = null,
+    val violationStatus: ViolationStatus? = null,
+    val vulnerabilityStatus: VulnerabilityStatus? = null,
+    val exclusionStatus: ExclusionStatus? = null
 ) {
     fun check(pkg: PackageInfo) =
         matchStringContains(text, pkg.metadata.id.toCoordinates())
@@ -226,25 +226,21 @@ data class PackagesFilter(
 }
 
 enum class IssueStatus {
-    ALL,
     HAS_ISSUES,
     NO_ISSUES
 }
 
 enum class ViolationStatus {
-    ALL,
     HAS_VIOLATIONS,
     NO_VIOLATIONS
 }
 
 enum class VulnerabilityStatus {
-    ALL,
     HAS_VULNERABILITY,
     NO_VULNERABILITY
 }
 
 enum class ExclusionStatus {
-    ALL,
     EXCLUDED,
     INCLUDED
 }

--- a/src/main/kotlin/ui/violations/Violations.kt
+++ b/src/main/kotlin/ui/violations/Violations.kt
@@ -89,7 +89,7 @@ private fun TitleRow(
                     data = state.severityFilter,
                     label = "Severity",
                     onFilterChange = onUpdateSeverityFilter,
-                    convert = { it?.name?.titlecase() ?: "" }
+                    convert = { it.name.titlecase() }
                 )
 
                 FilterButton(data = state.licenseFilter, label = "License", onFilterChange = onUpdateLicenseFilter)
@@ -98,7 +98,7 @@ private fun TitleRow(
                     data = state.licenseSourceFilter,
                     label = "License Source",
                     onFilterChange = onUpdateLicenseSourceFilter,
-                    convert = { it?.name?.titlecase() ?: "" }
+                    convert = { it.name.titlecase() }
                 )
 
                 FilterButton(data = state.ruleFilter, label = "Rule", onFilterChange = onUpdateRuleFilter)
@@ -107,14 +107,14 @@ private fun TitleRow(
                     data = state.identifierFilter,
                     label = "Package",
                     onFilterChange = onUpdateIdentifierFilter,
-                    convert = { it?.toCoordinates() ?: "" }
+                    convert = { it.toCoordinates() }
                 )
 
                 FilterButton(
                     data = state.resolutionStatusFilter,
                     label = "Resolution",
                     onFilterChange = onUpdateResolutionStatusFilter,
-                    convert = { it?.name?.titlecase() ?: "" }
+                    convert = { it.name.titlecase() }
                 )
             }
         }

--- a/src/main/kotlin/ui/violations/Violations.kt
+++ b/src/main/kotlin/ui/violations/Violations.kt
@@ -16,7 +16,9 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollbarAdapter
 import androidx.compose.material.Card
 import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -25,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseSource
@@ -48,9 +51,7 @@ import org.ossreviewtoolkit.workbench.util.SeverityIcon
 fun Violations(viewModel: ViolationsViewModel) {
     val filteredViolations by viewModel.filteredViolations.collectAsState()
 
-    Column(
-        modifier = Modifier.padding(15.dp).fillMaxSize()
-    ) {
+    Column {
         TitleRow(viewModel)
 
         ViolationsList(filteredViolations)
@@ -64,18 +65,26 @@ private fun TitleRow(viewModel: ViolationsViewModel) {
     val licenses by viewModel.licenses.collectAsState()
     val rules by viewModel.rules.collectAsState()
 
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(10.dp)
-    ) {
-        FilterTextField(filter.text) { viewModel.updateFilter(filter.copy(text = it)) }
-        FilterSeverity(filter.severity) { viewModel.updateFilter(filter.copy(severity = it)) }
-        FilterLicense(filter.license, licenses) { viewModel.updateFilter(filter.copy(license = it)) }
-        FilterLicenseSource(filter.licenseSource) { viewModel.updateFilter(filter.copy(licenseSource = it)) }
-        FilterRule(filter.rule, rules) { viewModel.updateFilter(filter.copy(rule = it)) }
-        FilterIdentifier(filter.identifier, identifiers) { viewModel.updateFilter(filter.copy(identifier = it)) }
-        FilterResolutionStatus(filter.resolutionStatus) { viewModel.updateFilter(filter.copy(resolutionStatus = it)) }
-    }
+    TopAppBar(
+        modifier = Modifier.zIndex(1f),
+        backgroundColor = MaterialTheme.colors.primary,
+        title = {},
+        actions = {
+            Row(modifier = Modifier.padding(vertical = 5.dp), horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                FilterTextField(filter.text) { viewModel.updateFilter(filter.copy(text = it)) }
+                FilterSeverity(filter.severity) { viewModel.updateFilter(filter.copy(severity = it)) }
+                FilterLicense(filter.license, licenses) { viewModel.updateFilter(filter.copy(license = it)) }
+                FilterLicenseSource(filter.licenseSource) { viewModel.updateFilter(filter.copy(licenseSource = it)) }
+                FilterRule(filter.rule, rules) { viewModel.updateFilter(filter.copy(rule = it)) }
+                FilterIdentifier(filter.identifier, identifiers) {
+                    viewModel.updateFilter(filter.copy(identifier = it))
+                }
+                FilterResolutionStatus(filter.resolutionStatus) {
+                    viewModel.updateFilter(filter.copy(resolutionStatus = it))
+                }
+            }
+        }
+    )
 }
 
 @Composable
@@ -189,13 +198,13 @@ private fun FilterResolutionStatus(
 @Composable
 fun ViolationsList(violations: List<Violation>) {
     if (violations.isEmpty()) {
-        Text("No violations found.", modifier = Modifier.padding(top = 15.dp))
+        Text("No violations found.", modifier = Modifier.padding(15.dp))
     } else {
-        Box(modifier = Modifier.fillMaxSize().padding(top = 15.dp)) {
+        Box(modifier = Modifier.fillMaxSize()) {
             val listState = rememberLazyListState()
 
             LazyColumn(
-                contentPadding = PaddingValues(vertical = 15.dp),
+                contentPadding = PaddingValues(15.dp),
                 verticalArrangement = Arrangement.spacedBy(10.dp),
                 state = listState
             ) {

--- a/src/main/kotlin/ui/violations/Violations.kt
+++ b/src/main/kotlin/ui/violations/Violations.kt
@@ -73,7 +73,7 @@ private fun TitleRow(
     onUpdateIdentifierFilter: (identifier: Identifier?) -> Unit,
     onUpdateLicenseFilter: (license: SpdxSingleLicenseExpression?) -> Unit,
     onUpdateLicenseSourceFilter: (licenseSource: LicenseSource?) -> Unit,
-    onUpdateResolutionStatusFilter: (resolutionStatus: ResolutionStatus) -> Unit,
+    onUpdateResolutionStatusFilter: (resolutionStatus: ResolutionStatus?) -> Unit,
     onUpdateRuleFilter: (rule: String?) -> Unit,
     onUpdateSeverityFilter: (severity: Severity?) -> Unit
 ) {
@@ -114,7 +114,7 @@ private fun TitleRow(
                     data = state.resolutionStatusFilter,
                     label = "Resolution",
                     onFilterChange = onUpdateResolutionStatusFilter,
-                    convert = { it.name.titlecase() }
+                    convert = { it?.name?.titlecase() ?: "" }
                 )
             }
         }

--- a/src/main/kotlin/ui/violations/ViolationsState.kt
+++ b/src/main/kotlin/ui/violations/ViolationsState.kt
@@ -14,7 +14,7 @@ data class ViolationsState(
     val identifierFilter: FilterData<Identifier?>,
     val licenseFilter: FilterData<SpdxSingleLicenseExpression?>,
     val licenseSourceFilter: FilterData<LicenseSource?>,
-    val resolutionStatusFilter: FilterData<ResolutionStatus>,
+    val resolutionStatusFilter: FilterData<ResolutionStatus?>,
     val ruleFilter: FilterData<String?>,
     val severityFilter: FilterData<Severity?>
 ) {
@@ -25,7 +25,7 @@ data class ViolationsState(
             identifierFilter = FilterData(null, emptyList()),
             licenseFilter = FilterData(null, emptyList()),
             licenseSourceFilter = FilterData(null, emptyList()),
-            resolutionStatusFilter = FilterData(ResolutionStatus.ALL, emptyList()),
+            resolutionStatusFilter = FilterData(null, emptyList()),
             ruleFilter = FilterData(null, emptyList()),
             severityFilter = FilterData(null, emptyList()),
         )

--- a/src/main/kotlin/ui/violations/ViolationsState.kt
+++ b/src/main/kotlin/ui/violations/ViolationsState.kt
@@ -22,12 +22,12 @@ data class ViolationsState(
         val INITIAL = ViolationsState(
             violations = emptyList(),
             textFilter = "",
-            identifierFilter = FilterData(null, emptyList()),
-            licenseFilter = FilterData(null, emptyList()),
-            licenseSourceFilter = FilterData(null, emptyList()),
-            resolutionStatusFilter = FilterData(null, emptyList()),
-            ruleFilter = FilterData(null, emptyList()),
-            severityFilter = FilterData(null, emptyList()),
+            identifierFilter = FilterData(),
+            licenseFilter = FilterData(),
+            licenseSourceFilter = FilterData(),
+            resolutionStatusFilter = FilterData(),
+            ruleFilter = FilterData(),
+            severityFilter = FilterData()
         )
     }
 }

--- a/src/main/kotlin/ui/violations/ViolationsState.kt
+++ b/src/main/kotlin/ui/violations/ViolationsState.kt
@@ -11,12 +11,12 @@ import org.ossreviewtoolkit.workbench.util.ResolutionStatus
 data class ViolationsState(
     val violations: List<Violation>,
     val textFilter: String,
-    val identifierFilter: FilterData<Identifier?>,
-    val licenseFilter: FilterData<SpdxSingleLicenseExpression?>,
-    val licenseSourceFilter: FilterData<LicenseSource?>,
-    val resolutionStatusFilter: FilterData<ResolutionStatus?>,
-    val ruleFilter: FilterData<String?>,
-    val severityFilter: FilterData<Severity?>
+    val identifierFilter: FilterData<Identifier>,
+    val licenseFilter: FilterData<SpdxSingleLicenseExpression>,
+    val licenseSourceFilter: FilterData<LicenseSource>,
+    val resolutionStatusFilter: FilterData<ResolutionStatus>,
+    val ruleFilter: FilterData<String>,
+    val severityFilter: FilterData<Severity>
 ) {
     companion object {
         val INITIAL = ViolationsState(

--- a/src/main/kotlin/ui/violations/ViolationsState.kt
+++ b/src/main/kotlin/ui/violations/ViolationsState.kt
@@ -1,0 +1,33 @@
+package org.ossreviewtoolkit.workbench.ui.violations
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.LicenseSource
+import org.ossreviewtoolkit.model.Severity
+import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
+import org.ossreviewtoolkit.workbench.model.FilterData
+import org.ossreviewtoolkit.workbench.model.Violation
+import org.ossreviewtoolkit.workbench.util.ResolutionStatus
+
+data class ViolationsState(
+    val violations: List<Violation>,
+    val textFilter: String,
+    val identifierFilter: FilterData<Identifier?>,
+    val licenseFilter: FilterData<SpdxSingleLicenseExpression?>,
+    val licenseSourceFilter: FilterData<LicenseSource?>,
+    val resolutionStatusFilter: FilterData<ResolutionStatus>,
+    val ruleFilter: FilterData<String?>,
+    val severityFilter: FilterData<Severity?>
+) {
+    companion object {
+        val INITIAL = ViolationsState(
+            violations = emptyList(),
+            textFilter = "",
+            identifierFilter = FilterData(null, emptyList()),
+            licenseFilter = FilterData(null, emptyList()),
+            licenseSourceFilter = FilterData(null, emptyList()),
+            resolutionStatusFilter = FilterData(ResolutionStatus.ALL, emptyList()),
+            ruleFilter = FilterData(null, emptyList()),
+            severityFilter = FilterData(null, emptyList()),
+        )
+    }
+}

--- a/src/main/kotlin/ui/violations/ViolationsViewModel.kt
+++ b/src/main/kotlin/ui/violations/ViolationsViewModel.kt
@@ -72,8 +72,8 @@ class ViolationsViewModel(private val ortModel: OrtModel = OrtModel.INSTANCE) {
                 options = listOf(null) + LicenseSource.values().toList()
             ),
             resolutionStatusFilter = FilterData(
-                selectedItem = ResolutionStatus.ALL,
-                options = ResolutionStatus.values().toList()
+                selectedItem = null,
+                options = listOf(null) + ResolutionStatus.values().toList()
             ),
             ruleFilter = FilterData(
                 selectedItem = null,
@@ -102,7 +102,7 @@ class ViolationsViewModel(private val ortModel: OrtModel = OrtModel.INSTANCE) {
         filter.value = filter.value.copy(licenseSource = licenseSource)
     }
 
-    fun updateResolutionStatusFilter(resolutionStatus: ResolutionStatus) {
+    fun updateResolutionStatusFilter(resolutionStatus: ResolutionStatus?) {
         filter.value = filter.value.copy(resolutionStatus = resolutionStatus)
     }
 
@@ -119,7 +119,7 @@ data class ViolationsFilter(
     val identifier: Identifier? = null,
     val license: SpdxSingleLicenseExpression? = null,
     val licenseSource: LicenseSource? = null,
-    val resolutionStatus: ResolutionStatus = ResolutionStatus.ALL,
+    val resolutionStatus: ResolutionStatus? = null,
     val rule: String? = null,
     val severity: Severity? = null,
     val text: String = ""

--- a/src/main/kotlin/ui/violations/ViolationsViewModel.kt
+++ b/src/main/kotlin/ui/violations/ViolationsViewModel.kt
@@ -59,29 +59,29 @@ class ViolationsViewModel(private val ortModel: OrtModel = OrtModel.INSTANCE) {
             textFilter = "",
             identifierFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + violations.mapNotNullTo(sortedSetOf()) { it.pkg }.toList()
+                options = violations.mapNotNullTo(sortedSetOf()) { it.pkg }.toList()
             ),
             licenseFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + violations.mapNotNullTo(sortedSetOf(SpdxExpressionStringComparator())) {
+                options = violations.mapNotNullTo(sortedSetOf(SpdxExpressionStringComparator())) {
                     it.license
                 }.toList()
             ),
             licenseSourceFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + LicenseSource.values().toList()
+                options = LicenseSource.values().toList()
             ),
             resolutionStatusFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + ResolutionStatus.values().toList()
+                options = ResolutionStatus.values().toList()
             ),
             ruleFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + violations.mapTo(sortedSetOf()) { it.rule }.toList()
+                options = violations.mapTo(sortedSetOf()) { it.rule }.toList()
             ),
             severityFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + Severity.values().toList()
+                options = Severity.values().toList()
             )
         )
     }

--- a/src/main/kotlin/ui/violations/ViolationsViewModel.kt
+++ b/src/main/kotlin/ui/violations/ViolationsViewModel.kt
@@ -57,32 +57,16 @@ class ViolationsViewModel(private val ortModel: OrtModel = OrtModel.INSTANCE) {
         _state.value = ViolationsState(
             violations = violations,
             textFilter = "",
-            identifierFilter = FilterData(
-                selectedItem = null,
-                options = violations.mapNotNullTo(sortedSetOf()) { it.pkg }.toList()
-            ),
+            identifierFilter = FilterData(violations.mapNotNullTo(sortedSetOf()) { it.pkg }.toList()),
             licenseFilter = FilterData(
-                selectedItem = null,
-                options = violations.mapNotNullTo(sortedSetOf(SpdxExpressionStringComparator())) {
+                violations.mapNotNullTo(sortedSetOf(SpdxExpressionStringComparator())) {
                     it.license
                 }.toList()
             ),
-            licenseSourceFilter = FilterData(
-                selectedItem = null,
-                options = LicenseSource.values().toList()
-            ),
-            resolutionStatusFilter = FilterData(
-                selectedItem = null,
-                options = ResolutionStatus.values().toList()
-            ),
-            ruleFilter = FilterData(
-                selectedItem = null,
-                options = violations.mapTo(sortedSetOf()) { it.rule }.toList()
-            ),
-            severityFilter = FilterData(
-                selectedItem = null,
-                options = Severity.values().toList()
-            )
+            licenseSourceFilter = FilterData(LicenseSource.values().toList()),
+            resolutionStatusFilter = FilterData(ResolutionStatus.values().toList()),
+            ruleFilter = FilterData(violations.mapTo(sortedSetOf()) { it.rule }.toList()),
+            severityFilter = FilterData(Severity.values().toList())
         )
     }
 

--- a/src/main/kotlin/ui/violations/ViolationsViewModel.kt
+++ b/src/main/kotlin/ui/violations/ViolationsViewModel.kt
@@ -4,14 +4,13 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.LicenseSource
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
+import org.ossreviewtoolkit.workbench.model.FilterData
 import org.ossreviewtoolkit.workbench.model.OrtModel
 import org.ossreviewtoolkit.workbench.model.Violation
 import org.ossreviewtoolkit.workbench.util.ResolutionStatus
@@ -24,75 +23,123 @@ import org.ossreviewtoolkit.workbench.util.matchValue
 class ViolationsViewModel(private val ortModel: OrtModel = OrtModel.INSTANCE) {
     private val scope = CoroutineScope(Dispatchers.Default)
 
-    private val _violations = MutableStateFlow(emptyList<Violation>())
-    val violations: StateFlow<List<Violation>> get() = _violations
+    private val violations = MutableStateFlow(emptyList<Violation>())
+    private val filter = MutableStateFlow(ViolationsFilter())
 
-    private val _filteredViolations = MutableStateFlow(emptyList<Violation>())
-    val filteredViolations: StateFlow<List<Violation>> get() = _filteredViolations
-
-    private val _identifiers = MutableStateFlow(emptyList<Identifier>())
-    val identifiers: StateFlow<List<Identifier>> get() = _identifiers
-
-    private val _licenses = MutableStateFlow(emptyList<SpdxSingleLicenseExpression>())
-    val licenses: StateFlow<List<SpdxSingleLicenseExpression>> get() = _licenses
-
-    private val _rules = MutableStateFlow(emptyList<String>())
-    val rules: StateFlow<List<String>> get() = _rules
-
-    private val _filter = MutableStateFlow(ViolationsFilter())
-    val filter: StateFlow<ViolationsFilter> get() = _filter
+    private val _state = MutableStateFlow(ViolationsState.INITIAL)
+    val state: StateFlow<ViolationsState> get() = _state
 
     init {
-        scope.launch {
-            ortModel.api.collect { api ->
-                val violations = api.getViolations()
-                _violations.value = violations
-                // TODO: Check how to do this when declaring `_identifiers` and `_licenses` and `_rules`.
-                _identifiers.value = violations.mapNotNullTo(sortedSetOf()) { it.pkg }.toList()
-                _licenses.value = violations.mapNotNullTo(
-                    sortedSetOf(comparator = SpdxExpressionStringComparator())
-                ) { it.license }.toList()
-                _rules.value = violations.mapTo(sortedSetOf()) { it.rule }.toList()
-            }
-        }
+        scope.launch { ortModel.api.collect { violations.value = it.getViolations() } }
+
+        scope.launch { violations.collect { initState(it) } }
 
         scope.launch {
-            combine(violations, filter) { violations, filter ->
-                violations.filter(filter::check)
-            }.collect { _filteredViolations.value = it }
+            filter.collect { newFilter ->
+                val oldState = state.value
+                _state.value = oldState.copy(
+                    violations = violations.value.filter(newFilter::check),
+                    textFilter = newFilter.text,
+                    identifierFilter = oldState.identifierFilter.copy(selectedItem = newFilter.identifier),
+                    licenseFilter = oldState.licenseFilter.copy(selectedItem = newFilter.license),
+                    licenseSourceFilter = oldState.licenseSourceFilter.copy(selectedItem = newFilter.licenseSource),
+                    resolutionStatusFilter = oldState.resolutionStatusFilter.copy(
+                        selectedItem = newFilter.resolutionStatus
+                    ),
+                    ruleFilter = oldState.ruleFilter.copy(selectedItem = newFilter.rule),
+                    severityFilter = oldState.severityFilter.copy(selectedItem = newFilter.severity)
+                )
+            }
         }
     }
 
-    fun updateFilter(filter: ViolationsFilter) {
-        _filter.value = filter
+    private fun initState(violations: List<Violation>) {
+        _state.value = ViolationsState(
+            violations = violations,
+            textFilter = "",
+            identifierFilter = FilterData(
+                selectedItem = null,
+                options = listOf(null) + violations.mapNotNullTo(sortedSetOf()) { it.pkg }.toList()
+            ),
+            licenseFilter = FilterData(
+                selectedItem = null,
+                options = listOf(null) + violations.mapNotNullTo(sortedSetOf(SpdxExpressionStringComparator())) {
+                    it.license
+                }.toList()
+            ),
+            licenseSourceFilter = FilterData(
+                selectedItem = null,
+                options = listOf(null) + LicenseSource.values().toList()
+            ),
+            resolutionStatusFilter = FilterData(
+                selectedItem = ResolutionStatus.ALL,
+                options = ResolutionStatus.values().toList()
+            ),
+            ruleFilter = FilterData(
+                selectedItem = null,
+                options = listOf(null) + violations.mapTo(sortedSetOf()) { it.rule }.toList()
+            ),
+            severityFilter = FilterData(
+                selectedItem = null,
+                options = listOf(null) + Severity.values().toList()
+            )
+        )
+    }
+
+    fun updateTextFilter(text: String) {
+        filter.value = filter.value.copy(text = text)
+    }
+
+    fun updateIdentifierFilter(identifier: Identifier?) {
+        filter.value = filter.value.copy(identifier = identifier)
+    }
+
+    fun updateLicenseFilter(license: SpdxSingleLicenseExpression?) {
+        filter.value = filter.value.copy(license = license)
+    }
+
+    fun updateLicenseSourceFilter(licenseSource: LicenseSource?) {
+        filter.value = filter.value.copy(licenseSource = licenseSource)
+    }
+
+    fun updateResolutionStatusFilter(resolutionStatus: ResolutionStatus) {
+        filter.value = filter.value.copy(resolutionStatus = resolutionStatus)
+    }
+
+    fun updateRuleFilter(rule: String?) {
+        filter.value = filter.value.copy(rule = rule)
+    }
+
+    fun updateSeverityFilter(severity: Severity?) {
+        filter.value = filter.value.copy(severity = severity)
     }
 }
 
 data class ViolationsFilter(
     val identifier: Identifier? = null,
-    val license: String = "",
+    val license: SpdxSingleLicenseExpression? = null,
     val licenseSource: LicenseSource? = null,
     val resolutionStatus: ResolutionStatus = ResolutionStatus.ALL,
-    val rule: String = "",
+    val rule: String? = null,
     val severity: Severity? = null,
     val text: String = ""
 ) {
     fun check(violation: Violation) =
         matchValue(identifier, violation.pkg)
-                && matchString(license, violation.license.toString())
+                && matchValue(license, violation.license)
                 && matchValue(licenseSource, violation.licenseSource)
                 && matchResolutionStatus(resolutionStatus, violation.resolutions)
                 && matchString(rule, violation.rule)
                 && matchValue(severity, violation.severity)
                 && matchStringContains(
-                    text,
-                    listOfNotNull(
-                        violation.pkg?.toCoordinates(),
-                        violation.rule,
-                        violation.license?.toString(),
-                        violation.licenseSource?.name,
-                        violation.message,
-                        violation.howToFix
-                    )
-                )
+            text,
+            listOfNotNull(
+                violation.pkg?.toCoordinates(),
+                violation.rule,
+                violation.license?.toString(),
+                violation.licenseSource?.name,
+                violation.message,
+                violation.howToFix
+            )
+        )
 }

--- a/src/main/kotlin/ui/vulnerabilities/Vulnerabilities.kt
+++ b/src/main/kotlin/ui/vulnerabilities/Vulnerabilities.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 
@@ -37,7 +36,6 @@ import org.ossreviewtoolkit.model.config.VulnerabilityResolution
 import org.ossreviewtoolkit.model.config.VulnerabilityResolutionReason
 import org.ossreviewtoolkit.utils.common.titlecase
 import org.ossreviewtoolkit.workbench.model.DecoratedVulnerability
-import org.ossreviewtoolkit.workbench.model.FilterData
 import org.ossreviewtoolkit.workbench.util.ExpandableText
 import org.ossreviewtoolkit.workbench.util.FilterButton
 import org.ossreviewtoolkit.workbench.util.FilterTextField
@@ -81,86 +79,37 @@ private fun TitleRow(
         actions = {
             Row(modifier = Modifier.padding(vertical = 5.dp), horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                 FilterTextField(state.textFilter, onFilterChange = onUpdateTextFilter)
-                FilterAdvisor(state.advisorFilter, onUpdateAdvisorsFilter)
-                FilterScoringSystem(state.scoringSystemFilter, onUpdateScoringSystemsFilter)
-                FilterSeverity(state.severityFilter, onUpdateSeveritiesFilter)
-                FilterIdentifier(state.identifierFilter, onUpdateIdentifiersFilter)
-                FilterResolutionStatus(state.resolutionStatusFilter, onUpdateResolutionStatusFilter)
+
+                FilterButton(data = state.advisorFilter, label = "Advisor", onFilterChange = onUpdateAdvisorsFilter)
+
+                FilterButton(
+                    data = state.scoringSystemFilter,
+                    label = "Scoring System",
+                    onFilterChange = onUpdateScoringSystemsFilter
+                )
+
+                FilterButton(
+                    data = state.severityFilter,
+                    label = "Severity",
+                    onFilterChange = onUpdateSeveritiesFilter
+                )
+
+                FilterButton(
+                    data = state.identifierFilter,
+                    label = "Package",
+                    onFilterChange = onUpdateIdentifiersFilter,
+                    convert = { it?.toCoordinates() ?: "" }
+                )
+
+                FilterButton(
+                    data = state.resolutionStatusFilter,
+                    label = "Resolution",
+                    onFilterChange = onUpdateResolutionStatusFilter,
+                    convert = { it.name.titlecase() }
+                )
             }
         }
     )
-}
-
-@Composable
-private fun FilterAdvisor(filter: FilterData<String?>, onAdvisorChange: (String?) -> Unit) {
-    FilterButton(
-        selectedItem = filter.selectedItem,
-        items = filter.options,
-        onFilterChange = onAdvisorChange,
-        buttonContent = { if (it == null) Text("Advisor") else Text(it) }
-    ) { item ->
-        if (item == null) Text("All") else Text(item)
-    }
-}
-
-@Composable
-private fun FilterScoringSystem(filter: FilterData<String?>, onScoringSystemChange: (String?) -> Unit) {
-    FilterButton(
-        selectedItem = filter.selectedItem,
-        items = filter.options,
-        onFilterChange = onScoringSystemChange,
-        buttonContent = { if (it == null) Text("Scoring System") else Text(it) },
-        buttonWidth = 150.dp,
-        dropdownWidth = 150.dp
-    ) { item ->
-        if (item == null) Text("All") else Text(item)
-    }
-}
-
-@Composable
-private fun FilterSeverity(filter: FilterData<String?>, onSeverityChange: (String?) -> Unit) {
-    FilterButton(
-        selectedItem = filter.selectedItem,
-        items = filter.options,
-        onFilterChange = onSeverityChange,
-        buttonContent = { if (it == null) Text("Severity") else Text(it) }
-    ) { item ->
-        if (item == null) Text("All") else Text(item)
-    }
-}
-
-@Composable
-private fun IdentifierText(identifier: Identifier) {
-    Text(identifier.toCoordinates(), maxLines = 1, overflow = TextOverflow.Ellipsis)
-}
-
-@Composable
-private fun FilterIdentifier(filter: FilterData<Identifier?>, onIdentifierChange: (Identifier?) -> Unit) {
-    FilterButton(
-        selectedItem = filter.selectedItem,
-        items = filter.options,
-        onFilterChange = onIdentifierChange,
-        buttonContent = { if (it == null) Text("Package") else IdentifierText(it) },
-        buttonWidth = 200.dp,
-        dropdownWidth = 500.dp
-    ) { item ->
-        if (item == null) Text("All") else IdentifierText(item)
-    }
-}
-
-@Composable
-private fun FilterResolutionStatus(
-    filter: FilterData<ResolutionStatus>,
-    onResolutionStatusChange: (ResolutionStatus) -> Unit
-) {
-    FilterButton(
-        selectedItem = filter.selectedItem,
-        items = filter.options,
-        onFilterChange = onResolutionStatusChange,
-        buttonContent = { if (it == ResolutionStatus.ALL) Text("Resolution") else Text(it.name.titlecase()) }
-    ) { item ->
-        Text(item.name.titlecase())
-    }
 }
 
 @Composable

--- a/src/main/kotlin/ui/vulnerabilities/Vulnerabilities.kt
+++ b/src/main/kotlin/ui/vulnerabilities/Vulnerabilities.kt
@@ -98,14 +98,14 @@ private fun TitleRow(
                     data = state.identifierFilter,
                     label = "Package",
                     onFilterChange = onUpdateIdentifiersFilter,
-                    convert = { it?.toCoordinates() ?: "" }
+                    convert = { it.toCoordinates() }
                 )
 
                 FilterButton(
                     data = state.resolutionStatusFilter,
                     label = "Resolution",
                     onFilterChange = onUpdateResolutionStatusFilter,
-                    convert = { it?.name?.titlecase() ?: "" }
+                    convert = { it.name.titlecase() }
                 )
             }
         }

--- a/src/main/kotlin/ui/vulnerabilities/Vulnerabilities.kt
+++ b/src/main/kotlin/ui/vulnerabilities/Vulnerabilities.kt
@@ -16,7 +16,9 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollbarAdapter
 import androidx.compose.material.Card
 import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -25,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 
 import java.net.URI
 
@@ -42,13 +45,10 @@ import org.ossreviewtoolkit.workbench.util.ResolutionStatus
 import org.ossreviewtoolkit.workbench.util.WebLink
 
 @Composable
-@Preview
 fun Vulnerabilities(viewModel: VulnerabilitiesViewModel) {
     val filteredVulnerabilities by viewModel.filteredVulnerabilities.collectAsState()
 
-    Column(
-        modifier = Modifier.padding(15.dp).fillMaxSize()
-    ) {
+    Column {
         TitleRow(viewModel)
 
         VulnerabilitiesList(filteredVulnerabilities)
@@ -63,19 +63,27 @@ private fun TitleRow(viewModel: VulnerabilitiesViewModel) {
     val scoringSystems by viewModel.scoringSystems.collectAsState()
     val severities by viewModel.severities.collectAsState()
 
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(10.dp)
-    ) {
-        FilterTextField(filter.text) { viewModel.updateFilter(filter.copy(text = it)) }
-        FilterAdvisor(filter.advisor, advisors) { viewModel.updateFilter(filter.copy(advisor = it)) }
-        FilterScoringSystem(filter.scoringSystem, scoringSystems) {
-            viewModel.updateFilter(filter.copy(scoringSystem = it))
+    TopAppBar(
+        modifier = Modifier.zIndex(1f),
+        backgroundColor = MaterialTheme.colors.primary,
+        title = {},
+        actions = {
+            Row(modifier = Modifier.padding(vertical = 5.dp), horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                FilterTextField(filter.text) { viewModel.updateFilter(filter.copy(text = it)) }
+                FilterAdvisor(filter.advisor, advisors) { viewModel.updateFilter(filter.copy(advisor = it)) }
+                FilterScoringSystem(filter.scoringSystem, scoringSystems) {
+                    viewModel.updateFilter(filter.copy(scoringSystem = it))
+                }
+                FilterSeverity(filter.severity, severities) { viewModel.updateFilter(filter.copy(severity = it)) }
+                FilterIdentifier(filter.identifier, identifiers) {
+                    viewModel.updateFilter(filter.copy(identifier = it))
+                }
+                FilterResolutionStatus(filter.resolutionStatus) {
+                    viewModel.updateFilter(filter.copy(resolutionStatus = it))
+                }
+            }
         }
-        FilterSeverity(filter.severity, severities) { viewModel.updateFilter(filter.copy(severity = it)) }
-        FilterIdentifier(filter.identifier, identifiers) { viewModel.updateFilter(filter.copy(identifier = it)) }
-        FilterResolutionStatus(filter.resolutionStatus) { viewModel.updateFilter(filter.copy(resolutionStatus = it)) }
-    }
+    )
 }
 
 @Composable
@@ -161,13 +169,13 @@ private fun FilterResolutionStatus(
 @Composable
 fun VulnerabilitiesList(vulnerabilities: List<DecoratedVulnerability>) {
     if (vulnerabilities.isEmpty()) {
-        Text("No vulnerabilities found.", modifier = Modifier.padding(top = 15.dp))
+        Text("No vulnerabilities found.", modifier = Modifier.padding(15.dp))
     } else {
-        Box(modifier = Modifier.fillMaxSize().padding(top = 15.dp)) {
+        Box(modifier = Modifier.fillMaxSize()) {
             val listState = rememberLazyListState()
 
             LazyColumn(
-                contentPadding = PaddingValues(vertical = 15.dp),
+                contentPadding = PaddingValues(15.dp),
                 verticalArrangement = Arrangement.spacedBy(10.dp),
                 state = listState
             ) {

--- a/src/main/kotlin/ui/vulnerabilities/Vulnerabilities.kt
+++ b/src/main/kotlin/ui/vulnerabilities/Vulnerabilities.kt
@@ -68,7 +68,7 @@ private fun TitleRow(
     onUpdateTextFilter: (text: String) -> Unit,
     onUpdateAdvisorsFilter: (advisor: String?) -> Unit,
     onUpdateIdentifiersFilter: (identifier: Identifier?) -> Unit,
-    onUpdateResolutionStatusFilter: (status: ResolutionStatus) -> Unit,
+    onUpdateResolutionStatusFilter: (status: ResolutionStatus?) -> Unit,
     onUpdateScoringSystemsFilter: (scoringSystem: String?) -> Unit,
     onUpdateSeveritiesFilter: (severity: String?) -> Unit,
 ) {
@@ -105,7 +105,7 @@ private fun TitleRow(
                     data = state.resolutionStatusFilter,
                     label = "Resolution",
                     onFilterChange = onUpdateResolutionStatusFilter,
-                    convert = { it.name.titlecase() }
+                    convert = { it?.name?.titlecase() ?: "" }
                 )
             }
         }

--- a/src/main/kotlin/ui/vulnerabilities/VulnerabilitiesState.kt
+++ b/src/main/kotlin/ui/vulnerabilities/VulnerabilitiesState.kt
@@ -18,11 +18,11 @@ data class VulnerabilitiesState(
         val INITIAL = VulnerabilitiesState(
             vulnerabilities = emptyList(),
             textFilter = "",
-            advisorFilter = FilterData(null, emptyList()),
-            identifierFilter = FilterData(null, emptyList()),
-            resolutionStatusFilter = FilterData(null, emptyList()),
-            scoringSystemFilter = FilterData(null, emptyList()),
-            severityFilter = FilterData(null, emptyList())
+            advisorFilter = FilterData(),
+            identifierFilter = FilterData(),
+            resolutionStatusFilter = FilterData(),
+            scoringSystemFilter = FilterData(),
+            severityFilter = FilterData()
         )
     }
 }

--- a/src/main/kotlin/ui/vulnerabilities/VulnerabilitiesState.kt
+++ b/src/main/kotlin/ui/vulnerabilities/VulnerabilitiesState.kt
@@ -8,11 +8,11 @@ import org.ossreviewtoolkit.workbench.util.ResolutionStatus
 data class VulnerabilitiesState(
     val vulnerabilities: List<DecoratedVulnerability>,
     val textFilter: String,
-    val advisorFilter: FilterData<String?>,
-    val scoringSystemFilter: FilterData<String?>,
-    val severityFilter: FilterData<String?>,
-    val identifierFilter: FilterData<Identifier?>,
-    val resolutionStatusFilter: FilterData<ResolutionStatus?>
+    val advisorFilter: FilterData<String>,
+    val scoringSystemFilter: FilterData<String>,
+    val severityFilter: FilterData<String>,
+    val identifierFilter: FilterData<Identifier>,
+    val resolutionStatusFilter: FilterData<ResolutionStatus>
 ) {
     companion object {
         val INITIAL = VulnerabilitiesState(

--- a/src/main/kotlin/ui/vulnerabilities/VulnerabilitiesState.kt
+++ b/src/main/kotlin/ui/vulnerabilities/VulnerabilitiesState.kt
@@ -1,0 +1,28 @@
+package org.ossreviewtoolkit.workbench.ui.vulnerabilities
+
+import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.workbench.model.DecoratedVulnerability
+import org.ossreviewtoolkit.workbench.model.FilterData
+import org.ossreviewtoolkit.workbench.util.ResolutionStatus
+
+data class VulnerabilitiesState(
+    val vulnerabilities: List<DecoratedVulnerability>,
+    val textFilter: String,
+    val advisorFilter: FilterData<String?>,
+    val scoringSystemFilter: FilterData<String?>,
+    val severityFilter: FilterData<String?>,
+    val identifierFilter: FilterData<Identifier?>,
+    val resolutionStatusFilter: FilterData<ResolutionStatus>
+) {
+    companion object {
+        val INITIAL = VulnerabilitiesState(
+            vulnerabilities = emptyList(),
+            textFilter = "",
+            advisorFilter = FilterData(null, emptyList()),
+            identifierFilter = FilterData(null, emptyList()),
+            resolutionStatusFilter = FilterData(ResolutionStatus.ALL, emptyList()),
+            scoringSystemFilter = FilterData(null, emptyList()),
+            severityFilter = FilterData(null, emptyList())
+        )
+    }
+}

--- a/src/main/kotlin/ui/vulnerabilities/VulnerabilitiesState.kt
+++ b/src/main/kotlin/ui/vulnerabilities/VulnerabilitiesState.kt
@@ -12,7 +12,7 @@ data class VulnerabilitiesState(
     val scoringSystemFilter: FilterData<String?>,
     val severityFilter: FilterData<String?>,
     val identifierFilter: FilterData<Identifier?>,
-    val resolutionStatusFilter: FilterData<ResolutionStatus>
+    val resolutionStatusFilter: FilterData<ResolutionStatus?>
 ) {
     companion object {
         val INITIAL = VulnerabilitiesState(
@@ -20,7 +20,7 @@ data class VulnerabilitiesState(
             textFilter = "",
             advisorFilter = FilterData(null, emptyList()),
             identifierFilter = FilterData(null, emptyList()),
-            resolutionStatusFilter = FilterData(ResolutionStatus.ALL, emptyList()),
+            resolutionStatusFilter = FilterData(null, emptyList()),
             scoringSystemFilter = FilterData(null, emptyList()),
             severityFilter = FilterData(null, emptyList())
         )

--- a/src/main/kotlin/ui/vulnerabilities/VulnerabilitiesViewModel.kt
+++ b/src/main/kotlin/ui/vulnerabilities/VulnerabilitiesViewModel.kt
@@ -65,8 +65,8 @@ class VulnerabilitiesViewModel(private val ortModel: OrtModel = OrtModel.INSTANC
                 options = listOf(null) + vulnerabilities.mapTo(sortedSetOf()) { it.pkg }.toList()
             ),
             resolutionStatusFilter = FilterData(
-                selectedItem = ResolutionStatus.ALL,
-                options = ResolutionStatus.values().toList(),
+                selectedItem = null,
+                options = listOf(null) + ResolutionStatus.values().toList(),
             ),
             scoringSystemFilter = FilterData(
                 selectedItem = null,
@@ -95,7 +95,7 @@ class VulnerabilitiesViewModel(private val ortModel: OrtModel = OrtModel.INSTANC
         filter.value = filter.value.copy(identifier = identifier)
     }
 
-    fun updateResolutionStatusFilter(resolutionStatus: ResolutionStatus) {
+    fun updateResolutionStatusFilter(resolutionStatus: ResolutionStatus?) {
         filter.value = filter.value.copy(resolutionStatus = resolutionStatus)
     }
 
@@ -111,7 +111,7 @@ class VulnerabilitiesViewModel(private val ortModel: OrtModel = OrtModel.INSTANC
 data class VulnerabilitiesFilter(
     val advisor: String? = null,
     val identifier: Identifier? = null,
-    val resolutionStatus: ResolutionStatus = ResolutionStatus.ALL,
+    val resolutionStatus: ResolutionStatus? = null,
     val scoringSystem: String? = null,
     val severity: String? = null,
     val text: String = ""

--- a/src/main/kotlin/ui/vulnerabilities/VulnerabilitiesViewModel.kt
+++ b/src/main/kotlin/ui/vulnerabilities/VulnerabilitiesViewModel.kt
@@ -58,25 +58,25 @@ class VulnerabilitiesViewModel(private val ortModel: OrtModel = OrtModel.INSTANC
             textFilter = "",
             advisorFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + vulnerabilities.mapTo(sortedSetOf()) { it.advisor }.toList()
+                options = vulnerabilities.mapTo(sortedSetOf()) { it.advisor }.toList()
             ),
             identifierFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + vulnerabilities.mapTo(sortedSetOf()) { it.pkg }.toList()
+                options = vulnerabilities.mapTo(sortedSetOf()) { it.pkg }.toList()
             ),
             resolutionStatusFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + ResolutionStatus.values().toList(),
+                options = ResolutionStatus.values().toList(),
             ),
             scoringSystemFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + vulnerabilities.flatMapTo(sortedSetOf()) { vulnerability ->
+                options = vulnerabilities.flatMapTo(sortedSetOf()) { vulnerability ->
                     vulnerability.references.mapNotNull { it.scoringSystem }
                 }.toList()
             ),
             severityFilter = FilterData(
                 selectedItem = null,
-                options = listOf(null) + vulnerabilities.flatMapTo(sortedSetOf()) { vulnerability ->
+                options = vulnerabilities.flatMapTo(sortedSetOf()) { vulnerability ->
                     vulnerability.references.mapNotNull { it.severity }
                 }.toList()
             )

--- a/src/main/kotlin/ui/vulnerabilities/VulnerabilitiesViewModel.kt
+++ b/src/main/kotlin/ui/vulnerabilities/VulnerabilitiesViewModel.kt
@@ -56,27 +56,16 @@ class VulnerabilitiesViewModel(private val ortModel: OrtModel = OrtModel.INSTANC
         _state.value = VulnerabilitiesState(
             vulnerabilities = vulnerabilities,
             textFilter = "",
-            advisorFilter = FilterData(
-                selectedItem = null,
-                options = vulnerabilities.mapTo(sortedSetOf()) { it.advisor }.toList()
-            ),
-            identifierFilter = FilterData(
-                selectedItem = null,
-                options = vulnerabilities.mapTo(sortedSetOf()) { it.pkg }.toList()
-            ),
-            resolutionStatusFilter = FilterData(
-                selectedItem = null,
-                options = ResolutionStatus.values().toList(),
-            ),
+            advisorFilter = FilterData(vulnerabilities.mapTo(sortedSetOf()) { it.advisor }.toList()),
+            identifierFilter = FilterData(vulnerabilities.mapTo(sortedSetOf()) { it.pkg }.toList()),
+            resolutionStatusFilter = FilterData(ResolutionStatus.values().toList()),
             scoringSystemFilter = FilterData(
-                selectedItem = null,
-                options = vulnerabilities.flatMapTo(sortedSetOf()) { vulnerability ->
+                vulnerabilities.flatMapTo(sortedSetOf()) { vulnerability ->
                     vulnerability.references.mapNotNull { it.scoringSystem }
                 }.toList()
             ),
             severityFilter = FilterData(
-                selectedItem = null,
-                options = vulnerabilities.flatMapTo(sortedSetOf()) { vulnerability ->
+                vulnerabilities.flatMapTo(sortedSetOf()) { vulnerability ->
                     vulnerability.references.mapNotNull { it.severity }
                 }.toList()
             )

--- a/src/main/kotlin/util/FilterButton.kt
+++ b/src/main/kotlin/util/FilterButton.kt
@@ -22,7 +22,7 @@ import org.ossreviewtoolkit.workbench.model.FilterData
 fun <T> FilterButton(
     data: FilterData<T>,
     label: String,
-    onFilterChange: (T) -> Unit,
+    onFilterChange: (T?) -> Unit,
     convert: (T) -> String = { it.toString() }
 ) {
     var expanded by rememberSaveable { mutableStateOf(false) }
@@ -37,16 +37,21 @@ fun <T> FilterButton(
         }
 
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            DropdownMenuItem(onClick = {
+                expanded = false
+                onFilterChange(null)
+            }) {
+                CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
+                    Text("No filter", fontStyle = FontStyle.Italic, overflow = TextOverflow.Ellipsis)
+                }
+            }
+
             data.options.forEach { item ->
                 DropdownMenuItem(onClick = {
                     expanded = false
                     onFilterChange(item)
                 }) {
-                    if (item == null) {
-                        CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
-                            Text("No filter", fontStyle = FontStyle.Italic, overflow = TextOverflow.Ellipsis)
-                        }
-                    } else {
+                    if (item != null) {
                         Text(convert(item), overflow = TextOverflow.Ellipsis)
                     }
                 }

--- a/src/main/kotlin/util/FilterButton.kt
+++ b/src/main/kotlin/util/FilterButton.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import org.ossreviewtoolkit.workbench.model.FilterData
 
 @Composable
-fun <T> FilterButton(
+fun <T : Any> FilterButton(
     data: FilterData<T>,
     label: String,
     onFilterChange: (T?) -> Unit,
@@ -51,9 +51,7 @@ fun <T> FilterButton(
                     expanded = false
                     onFilterChange(item)
                 }) {
-                    if (item != null) {
-                        Text(convert(item), overflow = TextOverflow.Ellipsis)
-                    }
+                    Text(convert(item), overflow = TextOverflow.Ellipsis)
                 }
             }
         }

--- a/src/main/kotlin/util/FilterButton.kt
+++ b/src/main/kotlin/util/FilterButton.kt
@@ -3,17 +3,25 @@ package org.ossreviewtoolkit.workbench.util
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.ContentAlpha
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.LocalContentAlpha
 import androidx.compose.material.OutlinedButton
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+
+import org.ossreviewtoolkit.workbench.model.FilterData
 
 @Composable
 fun <T> FilterButton(
@@ -43,6 +51,43 @@ fun <T> FilterButton(
                     onFilterChange(item)
                 }) {
                     dropdownItem(item)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun <T> FilterButton(
+    data: FilterData<T>,
+    label: String,
+    onFilterChange: (T) -> Unit,
+    convert: (T) -> String = { it.toString() }
+) {
+    var expanded by rememberSaveable { mutableStateOf(false) }
+
+    Box {
+        OutlinedButton(onClick = { expanded = !expanded }) {
+            if (data.selectedItem == null) {
+                Text(label, overflow = TextOverflow.Ellipsis)
+            } else {
+                Text(convert(data.selectedItem), overflow = TextOverflow.Ellipsis)
+            }
+        }
+
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            data.options.forEach { item ->
+                DropdownMenuItem(onClick = {
+                    expanded = false
+                    onFilterChange(item)
+                }) {
+                    if (item == null) {
+                        CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
+                            Text("No filter", fontStyle = FontStyle.Italic, overflow = TextOverflow.Ellipsis)
+                        }
+                    } else {
+                        Text(convert(item), overflow = TextOverflow.Ellipsis)
+                    }
                 }
             }
         }

--- a/src/main/kotlin/util/FilterButton.kt
+++ b/src/main/kotlin/util/FilterButton.kt
@@ -1,8 +1,6 @@
 package org.ossreviewtoolkit.workbench.util
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
@@ -15,47 +13,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 
 import org.ossreviewtoolkit.workbench.model.FilterData
-
-@Composable
-fun <T> FilterButton(
-    selectedItem: T,
-    items: List<T>,
-    buttonWidth: Dp = 130.dp,
-    dropdownWidth: Dp = 130.dp,
-    onFilterChange: (T) -> Unit,
-    buttonContent: @Composable RowScope.(selectedItem: T) -> Unit,
-    dropdownItem: @Composable RowScope.(item: T) -> Unit
-) {
-    var expanded by rememberSaveable { mutableStateOf(false) }
-
-    Box {
-        OutlinedButton(onClick = { expanded = !expanded }, modifier = Modifier.width(buttonWidth)) {
-            buttonContent(selectedItem)
-        }
-
-        DropdownMenu(
-            expanded = expanded,
-            onDismissRequest = { expanded = false },
-            modifier = Modifier.width(dropdownWidth)
-        ) {
-            items.forEach { item ->
-                DropdownMenuItem(onClick = {
-                    expanded = false
-                    onFilterChange(item)
-                }) {
-                    dropdownItem(item)
-                }
-            }
-        }
-    }
-}
 
 @Composable
 fun <T> FilterButton(

--- a/src/main/kotlin/util/FilterMatchers.kt
+++ b/src/main/kotlin/util/FilterMatchers.kt
@@ -8,29 +8,28 @@ import org.ossreviewtoolkit.workbench.ui.packages.IssueStatus
 import org.ossreviewtoolkit.workbench.ui.packages.ViolationStatus
 import org.ossreviewtoolkit.workbench.ui.packages.VulnerabilityStatus
 
-fun matchExclusionStatus(filter: ExclusionStatus, value: Boolean) =
-    filter == ExclusionStatus.ALL
+fun matchExclusionStatus(filter: ExclusionStatus?, value: Boolean) =
+    filter == null
             || filter == ExclusionStatus.EXCLUDED && value
             || filter == ExclusionStatus.INCLUDED && !value
 
-fun matchIssueStatus(filter: IssueStatus, value: List<Issue>) =
-    filter == IssueStatus.ALL
+fun matchIssueStatus(filter: IssueStatus?, value: List<Issue>) =
+    filter == null
             || filter == IssueStatus.HAS_ISSUES && value.isNotEmpty()
             || filter == IssueStatus.NO_ISSUES && value.isEmpty()
 
 fun <T> matchResolutionStatus(filter: ResolutionStatus?, value: List<T>) =
     filter == null
-            || filter == ResolutionStatus.ALL
             || filter == ResolutionStatus.RESOLVED && value.isNotEmpty()
             || filter == ResolutionStatus.UNRESOLVED && value.isEmpty()
 
-fun matchViolationStatus(filter: ViolationStatus, value: List<Violation>) =
-    filter == ViolationStatus.ALL
+fun matchViolationStatus(filter: ViolationStatus?, value: List<Violation>) =
+    filter == null
             || filter == ViolationStatus.HAS_VIOLATIONS && value.isNotEmpty()
             || filter == ViolationStatus.NO_VIOLATIONS && value.isEmpty()
 
-fun matchVulnerabilityStatus(filter: VulnerabilityStatus, value: List<DecoratedVulnerability>) =
-    filter == VulnerabilityStatus.ALL
+fun matchVulnerabilityStatus(filter: VulnerabilityStatus?, value: List<DecoratedVulnerability>) =
+    filter == null
             || filter == VulnerabilityStatus.HAS_VULNERABILITY && value.isNotEmpty()
             || filter == VulnerabilityStatus.NO_VULNERABILITY && value.isEmpty()
 

--- a/src/main/kotlin/util/FilterMatchers.kt
+++ b/src/main/kotlin/util/FilterMatchers.kt
@@ -18,8 +18,9 @@ fun matchIssueStatus(filter: IssueStatus, value: List<Issue>) =
             || filter == IssueStatus.HAS_ISSUES && value.isNotEmpty()
             || filter == IssueStatus.NO_ISSUES && value.isEmpty()
 
-fun <T> matchResolutionStatus(filter: ResolutionStatus, value: List<T>) =
-    filter == ResolutionStatus.ALL
+fun <T> matchResolutionStatus(filter: ResolutionStatus?, value: List<T>) =
+    filter == null
+            || filter == ResolutionStatus.ALL
             || filter == ResolutionStatus.RESOLVED && value.isNotEmpty()
             || filter == ResolutionStatus.UNRESOLVED && value.isEmpty()
 
@@ -33,13 +34,15 @@ fun matchVulnerabilityStatus(filter: VulnerabilityStatus, value: List<DecoratedV
             || filter == VulnerabilityStatus.HAS_VULNERABILITY && value.isNotEmpty()
             || filter == VulnerabilityStatus.NO_VULNERABILITY && value.isEmpty()
 
-fun matchString(filter: String, vararg values: String) = filter.isEmpty() || filter in values
+fun matchString(filter: String?, vararg values: String) = filter.isNullOrEmpty() || filter in values
 
-fun matchString(filter: String, values: Collection<String>) = filter.isEmpty() || filter in values
+fun matchString(filter: String?, values: Collection<String>) = filter.isNullOrEmpty() || filter in values
 
-fun matchStringContains(filter: String, vararg values: String) = filter.isEmpty() || values.any { it.contains(filter) }
+fun matchStringContains(filter: String?, vararg values: String) =
+    filter.isNullOrEmpty() || values.any { it.contains(filter) }
 
-fun matchStringContains(filter: String, values: List<String>) = filter.isEmpty() || values.any { it.contains(filter) }
+fun matchStringContains(filter: String?, values: List<String>) =
+    filter.isNullOrEmpty() || values.any { it.contains(filter) }
 
 fun <T> matchValue(filter: T?, value: T) = filter == null || filter == value
 

--- a/src/main/kotlin/util/ResolutionStatus.kt
+++ b/src/main/kotlin/util/ResolutionStatus.kt
@@ -1,7 +1,6 @@
 package org.ossreviewtoolkit.workbench.util
 
 enum class ResolutionStatus {
-    ALL,
     RESOLVED,
     UNRESOLVED
 }


### PR DESCRIPTION
Align the layout of the `Issues`, `Packages`, `Violations`, and `Vulnerabilities` screens and refactor the filter logic. The refactoring is mainly a preparation for moving the filters to a side panel and sharing more code between the screens which will happen in a follow-up PR. Until then, the layout can break if the window is not wide enough to show all filters. See the commit messages for details.
