### PR TITLE
ci(github): Start enforcing of Conventional Commits

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,0 +1,74 @@
+# Commitlint configuration.
+# See: https://github.com/conventional-changelog/commitlint/blob/master/docs/reference-rules.md
+---
+parserPreset:
+  parserOpts:
+    headerPattern: '^(\w*)(?:\((.*)\))?!?: (.*)$'
+    breakingHeaderPattern: '^(\w*)(?:\((.*)\))?!: (.*)$'
+    headerCorrespondence: ['type', 'scope', 'subject']
+    noteKeywords: ['BREAKING CHANGE', 'BREAKING-CHANGE', '\[\d+\]:', 'Signed-off-by:']
+    revertPattern: '/^(?:Revert|revert:)\s"?([\s\S]+?)"?\s*This reverts commit (\w*)\./i'
+    revertCorrespondence: ['header', 'hash']
+rules:
+  body-leading-blank:
+    - 2
+    - always
+  body-max-line-length:
+    - 2
+    - always
+    - 75
+  footer-leading-blank:
+    - 2
+    - always
+  header-max-length:
+    - 2
+    - always
+    - 75
+  scope-case:
+    - 2
+    - always
+    - - camel-case
+      - kebab-case
+      - lower-case
+      - pascal-case
+      - snake-case
+      - upper-case
+  subject-case:
+    - 1
+    - always
+    - - pascal-case
+      - sentence-case
+      - start-case
+      - upper-case
+  subject-empty:
+    - 2
+    - never
+  subject-full-stop:
+    - 2
+    - never
+    - .
+  type-case:
+    - 2
+    - always
+    - lower-case
+  type-empty:
+    - 2
+    - never
+  type-enum:
+    - 2
+    - always
+    - - build
+      - chore
+      - ci
+      - deps
+      - docs
+      - feat
+      - fix
+      - perf
+      - refactor
+      - revert
+      - style
+      - test
+  signed-off-by:
+    - 2
+    - always

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,6 +9,15 @@ on:
       - main
 
 jobs:
+  commit-lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v5
+        with:
+          configFile: .commitlintrc.yml
   detekt:
     runs-on: ubuntu-latest
     env:

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    ":semanticCommitScopeDisabled",
+    ":semanticCommitTypeAll(deps)"
   ],
   "dependencyDashboard": false,
   "ignoreDeps": [


### PR DESCRIPTION
See [1]. This is a preparation for release automation including release notes. At the same time, configure Renovate to use "deps" as the type and no scope at all, see [2].

[1]: https://www.conventionalcommits.org/
[2]: https://docs.renovatebot.com/semantic-commits/