### PR TITLE
refactor: Extract tree composable

### DIFF
--- a/src/main/kotlin/composables/tree/Tree.kt
+++ b/src/main/kotlin/composables/tree/Tree.kt
@@ -1,0 +1,196 @@
+@file:OptIn(ExperimentalComposeUiApi::class)
+
+package org.ossreviewtoolkit.workbench.composables.tree
+
+import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+import org.ossreviewtoolkit.workbench.composables.Preview
+import org.ossreviewtoolkit.workbench.utils.MaterialIcon
+
+@Composable
+fun <VALUE> Tree(
+    modifier: Modifier = Modifier,
+    roots: List<TreeNode<VALUE>>,
+    startExpanded: Boolean = false,
+    listState: LazyListState = rememberLazyListState(),
+    indentation: Dp = 5.dp,
+    expandIcon: MaterialIcon = MaterialIcon.CHEVRON_RIGHT,
+    expandedIcon: MaterialIcon = MaterialIcon.EXPAND_MORE,
+    iconSize: Dp = 12.dp,
+    itemContent: @Composable (item: TreeItem<VALUE>, isSelected: Boolean) -> Unit = { item, isSelected ->
+        DefaultItemContent(item, isSelected)
+    }
+) {
+    Tree(
+        modifier = modifier,
+        state = TreeState(roots, startExpanded),
+        listState = listState,
+        indentation = indentation,
+        expandIcon = expandIcon,
+        expandedIcon = expandedIcon,
+        iconSize = iconSize,
+        itemContent = itemContent
+    )
+}
+
+@Composable
+fun <VALUE> Tree(
+    modifier: Modifier = Modifier,
+    state: TreeState<VALUE>,
+    listState: LazyListState = rememberLazyListState(),
+    indentation: Dp = 5.dp,
+    expandIcon: MaterialIcon = MaterialIcon.CHEVRON_RIGHT,
+    expandedIcon: MaterialIcon = MaterialIcon.EXPAND_MORE,
+    iconSize: Dp = 12.dp,
+    itemContent: @Composable (item: TreeItem<VALUE>, isSelected: Boolean) -> Unit = { item, isSelected ->
+        DefaultItemContent(item, isSelected)
+    }
+) {
+    fun handleKeyEvent(event: KeyEvent) =
+        when (event.type) {
+            KeyEventType.KeyUp -> {
+                when (event.key) {
+                    Key.DirectionDown -> {
+                        state.selectNextItem()
+                        true
+                    }
+
+                    Key.DirectionUp -> {
+                        state.selectPreviousItem()
+                        true
+                    }
+
+                    Key.DirectionLeft -> {
+                        state.collapseSelectedItem()
+                        true
+                    }
+
+                    Key.DirectionRight -> {
+                        state.expandSelectedItem()
+                        true
+                    }
+
+                    else -> false
+                }
+            }
+
+            else -> false
+        }
+
+    if (state.isItemAutoSelected) {
+        val selectedItemIndex = state.visibleItems.indexOf(state.selectedItem)
+        if (selectedItemIndex >= 0) {
+            LaunchedEffect(selectedItemIndex) {
+                listState.animateScrollToItem(selectedItemIndex)
+            }
+        }
+    }
+
+    LazyColumn(
+        state = listState,
+        modifier = modifier.onKeyEvent(::handleKeyEvent),
+        verticalArrangement = Arrangement.spacedBy(5.dp)
+    ) {
+        items(state.visibleItems.size) {
+            val item = state.visibleItems[it]
+            Row(
+                modifier = Modifier.padding(start = (indentation * item.level)),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                val icon = when {
+                    item.node.children.isNotEmpty() -> if (item.expanded) expandedIcon else expandIcon
+                    else -> null
+                }
+
+                if (icon != null) {
+                    Icon(
+                        painter = painterResource(icon.resource),
+                        contentDescription = null,
+                        modifier = Modifier.size(iconSize).clickable { state.toggleExpanded(item) }
+                    )
+                }
+
+                Box(
+                    modifier = Modifier.padding(start = if (icon == null) iconSize else 0.dp)
+                        .clickable { state.selectItem(item, isAutoSelected = false) }
+                ) {
+                    itemContent(item, item.index == state.selectedItem?.index)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun <VALUE> DefaultItemContent(item: TreeItem<VALUE>, isSelected: Boolean) {
+    Text(text = item.node.value.toString(), fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal)
+}
+
+@Composable
+@Preview
+fun TreePreview() {
+    val roots = listOf(
+        TreeNode(
+            value = "Root",
+            children = listOf(
+                TreeNode(
+                    value = "Child 1",
+                    children = listOf(
+                        TreeNode(value = "Child 1.1"),
+                        TreeNode(
+                            value = "Child 1.2",
+                            children = listOf(
+                                TreeNode(value = "Child.1.2.1")
+                            )
+                        ),
+                        TreeNode(value = "Child 1.3")
+                    )
+                ),
+                TreeNode(
+                    value = "Child 2",
+                    children = listOf(
+                        TreeNode(value = "Child 2.1"),
+                        TreeNode(value = "Child 2.2")
+                    )
+                )
+            )
+        ),
+        TreeNode(
+            value = "Root 2",
+            children = listOf(
+                TreeNode(value = "Child 1"),
+                TreeNode(value = "Child 2")
+            )
+        )
+    )
+
+    Preview {
+        Tree(roots = roots, startExpanded = true)
+    }
+}

--- a/src/main/kotlin/composables/tree/TreeState.kt
+++ b/src/main/kotlin/composables/tree/TreeState.kt
@@ -1,0 +1,144 @@
+package org.ossreviewtoolkit.workbench.composables.tree
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+class TreeState<VALUE>(roots: List<TreeNode<VALUE>>, startExpanded: Boolean = false) {
+    val items = buildItems(roots, startExpanded)
+
+    var visibleItems by mutableStateOf(emptyList<TreeItem<VALUE>>())
+        private set
+
+    var selectedItem: TreeItem<VALUE>? by mutableStateOf(null)
+        private set
+
+    var isItemAutoSelected by mutableStateOf(false)
+        private set
+
+    init {
+        updateVisibleItems()
+    }
+
+    private fun updateVisibleItems() {
+        var expandedLevel = 0
+
+        visibleItems = items.filter { item ->
+            if (item.level < expandedLevel) expandedLevel = item.level
+            if (item.level <= expandedLevel) {
+                if (item.expanded) expandedLevel = item.level + 1
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    fun selectItem(itemIndex: Int, isAutoSelected: Boolean) {
+        items.getOrNull(itemIndex)?.let { selectItem(it, isAutoSelected = isAutoSelected) }
+    }
+
+    fun selectItem(item: TreeItem<VALUE>, isAutoSelected: Boolean) {
+        if (item == selectedItem && !isAutoSelected) {
+            selectedItem = null
+            isItemAutoSelected = false
+        } else {
+            selectedItem = item
+            isItemAutoSelected = isAutoSelected
+        }
+    }
+
+    fun selectNextItem() {
+        if (selectedItem != null) {
+            val newIndex = visibleItems.indexOf(selectedItem) + 1
+
+            selectedItem = if (newIndex < visibleItems.size) {
+                visibleItems[newIndex]
+            } else {
+                visibleItems.first()
+            }
+        } else if (visibleItems.isNotEmpty()) {
+            selectedItem = visibleItems[0]
+        }
+    }
+
+    fun selectPreviousItem() {
+        if (selectedItem != null) {
+            val newIndex = visibleItems.indexOf(selectedItem) - 1
+
+            selectedItem = if (newIndex < 0) {
+                visibleItems.last()
+            } else {
+                visibleItems[newIndex]
+            }
+        } else if (visibleItems.isNotEmpty()) {
+            selectedItem = visibleItems.last()
+        }
+    }
+
+    fun toggleExpanded(item: TreeItem<VALUE>) {
+        item.expanded = !item.expanded
+        updateVisibleItems()
+    }
+
+    fun expandSelectedItem() {
+        selectedItem?.let {
+            if (!it.expanded) toggleExpanded(it)
+        }
+    }
+
+    fun collapseSelectedItem() {
+        selectedItem?.let {
+            if (it.expanded) toggleExpanded(it)
+        }
+    }
+
+    private fun getItemParent(item: TreeItem<VALUE>): TreeItem<VALUE>? {
+        var index = item.index - 1
+        while (index >= 0) {
+            if (items[index].level < item.level) return items[index]
+            index--
+        }
+
+        return null
+    }
+
+    fun expandItem(itemIndex: Int) {
+        var currentItem = items.getOrNull(itemIndex)
+
+        do {
+            currentItem = currentItem?.let { getItemParent(it) }
+            currentItem?.expanded = true
+        } while (currentItem != null && currentItem.level >= 0)
+
+        updateVisibleItems()
+    }
+}
+
+private fun <VALUE> buildItems(roots: List<TreeNode<VALUE>>, startExpanded: Boolean): List<TreeItem<VALUE>> {
+    var index = 0
+    return buildList {
+        fun addItem(level: Int, node: TreeNode<VALUE>) {
+            add(TreeItem(index = index, level = level, node = node, expanded = startExpanded))
+            index++
+
+            node.children.forEach { addItem(level = level + 1, it) }
+        }
+
+        roots.forEach { addItem(level = 0, node = it) }
+    }
+}
+
+class TreeNode<VALUE>(
+    val value: VALUE,
+    val children: List<TreeNode<VALUE>> = emptyList()
+)
+
+class TreeItem<VALUE>(
+    val index: Int,
+    val level: Int,
+    val node: TreeNode<VALUE>,
+    expanded: Boolean
+) {
+    var expanded by mutableStateOf(expanded)
+}

--- a/src/main/kotlin/ui/dependencies/DependenciesState.kt
+++ b/src/main/kotlin/ui/dependencies/DependenciesState.kt
@@ -5,9 +5,6 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-
 import org.ossreviewtoolkit.model.CuratedPackage
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.OrtIssue
@@ -15,16 +12,12 @@ import org.ossreviewtoolkit.model.PackageLinkage
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.Scope
 import org.ossreviewtoolkit.model.licenses.ResolvedLicenseInfo
+import org.ossreviewtoolkit.workbench.composables.tree.TreeNode
+import org.ossreviewtoolkit.workbench.composables.tree.TreeState
 
-class DependenciesState(private val dependencyTreeItems: List<DependencyTreeItem>) {
-    var initialized by mutableStateOf(false)
-        private set
-
+class DependenciesState(rootNodes: List<TreeNode<DependencyTreeItem>>) {
     var error: String? by mutableStateOf(null)
         private set
-
-    private val _filteredDependencyTreeItems = mutableStateListOf<DependencyTreeItem>()
-    val filteredDependencyTreeItems: List<DependencyTreeItem> get() = _filteredDependencyTreeItems
 
     var search by mutableStateOf("")
         private set
@@ -35,60 +28,7 @@ class DependenciesState(private val dependencyTreeItems: List<DependencyTreeItem
     private val _searchHits = mutableStateListOf<Int>()
     val searchHits: List<Int> get() = _searchHits
 
-    var isItemAutoSelected by mutableStateOf(false)
-        private set
-
-    var selectedItem: DependencyTreeItem? by mutableStateOf(null)
-        private set
-
-    suspend fun initialize() {
-        withContext(Dispatchers.Default) {
-            updateFilteredDependencyTreeItems()
-            initialized = true
-        }
-    }
-
-    fun selectItem(item: DependencyTreeItem, isAutoSelected: Boolean) {
-        if (item == selectedItem && !isAutoSelected) {
-            selectedItem = null
-            isItemAutoSelected = false
-        } else {
-            selectedItem = item
-            isItemAutoSelected = isAutoSelected
-        }
-    }
-
-    private fun selectItem(itemIndex: Int, isAutoSelected: Boolean) {
-        dependencyTreeItems.getOrNull(itemIndex)?.let { selectItem(it, isAutoSelected = isAutoSelected) }
-    }
-
-    fun selectNext() {
-        if (selectedItem != null) {
-            val newIndex = filteredDependencyTreeItems.indexOf(selectedItem) + 1
-
-            selectedItem = if (newIndex < filteredDependencyTreeItems.size) {
-                filteredDependencyTreeItems[newIndex]
-            } else {
-                filteredDependencyTreeItems.first()
-            }
-        } else if (filteredDependencyTreeItems.isNotEmpty()) {
-            selectedItem = filteredDependencyTreeItems[0]
-        }
-    }
-
-    fun selectPrevious() {
-        if (selectedItem != null) {
-            val newIndex = filteredDependencyTreeItems.indexOf(selectedItem) - 1
-
-            selectedItem = if (newIndex < 0) {
-                filteredDependencyTreeItems.last()
-            } else {
-                filteredDependencyTreeItems[newIndex]
-            }
-        } else if (filteredDependencyTreeItems.isNotEmpty()) {
-            selectedItem = filteredDependencyTreeItems.last()
-        }
-    }
+    val treeState: TreeState<DependencyTreeItem> = TreeState(rootNodes)
 
     fun selectNextSearchHit() {
         if (searchHits.isEmpty()) searchCurrentHit = -1 else searchCurrentHit++
@@ -96,8 +36,8 @@ class DependenciesState(private val dependencyTreeItems: List<DependencyTreeItem
         if (searchCurrentHit >= searchHits.size) searchCurrentHit = 0
 
         if (searchCurrentHit > -1) {
-            expandTree(searchHits[searchCurrentHit])
-            selectItem(searchHits[searchCurrentHit], isAutoSelected = true)
+            treeState.expandItem(searchHits[searchCurrentHit])
+            treeState.selectItem(searchHits[searchCurrentHit], isAutoSelected = true)
         }
     }
 
@@ -107,47 +47,9 @@ class DependenciesState(private val dependencyTreeItems: List<DependencyTreeItem
         if (searchCurrentHit < 0) searchCurrentHit = searchHits.size - 1
 
         if (searchCurrentHit > -1) {
-            expandTree(searchHits[searchCurrentHit])
-            selectItem(searchHits[searchCurrentHit], isAutoSelected = true)
+            treeState.expandItem(searchCurrentHit)
+            treeState.selectItem(searchHits[searchCurrentHit], isAutoSelected = true)
         }
-    }
-
-    fun expandSelectedItem() {
-        selectedItem?.let {
-            if (!it.expanded) toggleExpanded(it)
-        }
-    }
-
-    fun collapseSelectedItem() {
-        selectedItem?.let {
-            if (it.expanded) toggleExpanded(it)
-        }
-    }
-
-    private fun expandTree(itemIndex: Int) {
-        var currentItem = dependencyTreeItems.getOrNull(itemIndex)
-
-        do {
-            currentItem = currentItem?.let { getItemParent(it) }
-            currentItem?.expanded = true
-        } while (currentItem != null && currentItem.level >= 0)
-
-        updateFilteredDependencyTreeItems()
-    }
-
-    private fun getItemParent(item: DependencyTreeItem): DependencyTreeItem? {
-        var index = item.index - 1
-        while (index >= 0) {
-            if (dependencyTreeItems[index].level < item.level) return dependencyTreeItems[index]
-            index--
-        }
-
-        return null
-    }
-
-    fun toggleExpanded(item: DependencyTreeItem) {
-        item.expanded = !item.expanded
-        updateFilteredDependencyTreeItems()
     }
 
     fun updateSearch(search: String) {
@@ -158,66 +60,51 @@ class DependenciesState(private val dependencyTreeItems: List<DependencyTreeItem
         if (search.isNotBlank()) {
             val trimmedSearch = search.trim()
 
-            _searchHits += dependencyTreeItems.mapIndexedNotNull { index, item ->
-                if (item.name.contains(trimmedSearch)) index else null
+            _searchHits += treeState.items.mapIndexedNotNull { index, item ->
+                if (item.node.value.name.contains(trimmedSearch)) index else null
             }
         }
 
         searchCurrentHit = if (_searchHits.isEmpty()) -1 else 0
 
         if (searchCurrentHit >= 0) {
-            val item = dependencyTreeItems[searchHits[searchCurrentHit]]
-            expandTree(item.index)
-            selectItem(item, isAutoSelected = true)
-        }
-    }
-
-    private fun updateFilteredDependencyTreeItems() {
-        _filteredDependencyTreeItems.clear()
-
-        var expandedLevel = 0
-
-        dependencyTreeItems.forEach { item ->
-            if (item.level < expandedLevel) expandedLevel = item.level
-            if (item.level <= expandedLevel) {
-                _filteredDependencyTreeItems += item
-                if (item.expanded) expandedLevel = item.level + 1
-            }
+            val item = treeState.items[searchHits[searchCurrentHit]]
+            treeState.expandItem(item.index)
+            treeState.selectItem(item, isAutoSelected = true)
         }
     }
 }
 
-sealed class DependencyTreeItem(val index: Int, val level: Int, val hasChildren: Boolean) {
+sealed class DependencyTreeItem {
     abstract val name: String
-
-    var expanded by mutableStateOf(false)
 }
 
 class DependencyTreeProject(
-    index: Int,
-    level: Int,
     val project: Project,
     val linkage: PackageLinkage,
     val issues: List<OrtIssue>,
     val resolvedLicense: ResolvedLicenseInfo
-) : DependencyTreeItem(index, level, hasChildren = project.scopes.isNotEmpty()) {
+) : DependencyTreeItem() {
     override val name = project.id.toCoordinates()
 }
 
-class DependencyTreeScope(index: Int, level: Int, val project: Project, val scope: Scope) :
-    DependencyTreeItem(index, level, hasChildren = scope.dependencies.isNotEmpty()) {
+class DependencyTreeScope(val project: Project, val scope: Scope) : DependencyTreeItem() {
     override val name = scope.name
 }
 
 class DependencyTreePackage(
-    index: Int,
-    level: Int,
-    hasChildren: Boolean,
     val id: Identifier,
     val pkg: CuratedPackage?,
     val linkage: PackageLinkage,
     val issues: List<OrtIssue>,
     val resolvedLicense: ResolvedLicenseInfo?
-) : DependencyTreeItem(index, level, hasChildren) {
+) : DependencyTreeItem() {
+    override val name = id.toCoordinates()
+}
+
+class DependencyTreeError(
+    val id: Identifier,
+    val message: String
+) : DependencyTreeItem() {
     override val name = id.toCoordinates()
 }

--- a/src/main/kotlin/utils/MaterialIcon.kt
+++ b/src/main/kotlin/utils/MaterialIcon.kt
@@ -6,6 +6,7 @@ enum class MaterialIcon(val resource: String) {
     ASSESSMENT("material/assessment.svg"),
     BOOKMARK_BORDER("material/bookmark_border.svg"),
     BUG_REPORT("material/bug_report.svg"),
+    CHEVRON_RIGHT("material/chevron_right.svg"),
     ERROR("material/error.svg"),
     EXPAND_LESS("material/expand_less.svg"),
     EXPAND_MORE("material/expand_more.svg"),

--- a/src/main/resources/material/chevron_right.svg
+++ b/src/main/resources/material/chevron_right.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="48" width="48"><path d="m18.75 36-2.15-2.15 9.9-9.9-9.9-9.9 2.15-2.15L30.8 23.95Z"/></svg>


### PR DESCRIPTION
Extract the tree logic from the dependencies screen into a separate composable to make it reusable.