### PR TITLE
ci(renovate): Enforce semantic commits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",
+    ":semanticCommits",
     ":semanticCommitScopeDisabled",
     ":semanticCommitTypeAll(deps)"
   ],


### PR DESCRIPTION
Enfore semantic commits [1] because Renovate does not auto-detect them.

[1]: https://docs.renovatebot.com/semantic-commits/#manually-enabling-or-disabling-semantic-commits