### PR TITLE
build(Gradle): Stop using a Compose compiler development version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -120,10 +120,6 @@ tasks.test {
 }
 
 compose {
-    // See https://androidx.dev/storage/compose-compiler/repository
-    // and https://github.com/JetBrains/compose-jb/blob/master/VERSIONING.md#using-jetpack-compose-compiler.
-    kotlinCompilerPlugin.set("androidx.compose.compiler:compiler:1.4.0-dev-k1.8.0-33c0ad36f83")
-
     desktop {
         application {
             mainClass = "org.ossreviewtoolkit.workbench.MainKt"


### PR DESCRIPTION
This is not needed for Kotlin 1.8 compatibility anymore as of 804306c.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>