### PR TITLE
fix(Dependencies): Fix showing transitive dependencies

### DIFF
--- a/src/main/kotlin/ui/dependencies/DependenciesViewModel.kt
+++ b/src/main/kotlin/ui/dependencies/DependenciesViewModel.kt
@@ -54,7 +54,8 @@ class DependenciesViewModel(private val ortModel: OrtModel = OrtModel.INSTANCE) 
                         linkage = linkage,
                         issues = issues,
                         resolvedLicense = resolvedLicenses.getValue(id)
-                    )
+                    ),
+                    children = children
                 )
             } ?: TreeNode(
                 value = DependencyTreeError(


### PR DESCRIPTION
Fix showing transitive dependencies in the dependency tree view.

This is a fixup for 6e4eeb6.