### PR TITLE
Gradle: Set a duplicate handling strategy (to handle "classpath.index")

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,6 +92,10 @@ java {
     targetCompatibility = JavaVersion.VERSION_17
 }
 
+tasks.withType<Jar>().configureEach {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
 tasks.withType<KotlinCompile> {
     kotlinOptions {
         apiVersion = "1.8"


### PR DESCRIPTION
IntelliJ creates classpath.index files for the kotlin sources and the resources which can result in this error:

    Entry classpath.index is a duplicate but no duplicate handling
    strategy has been set.

Solve that by setting an appropriate duplicate handling strategy to exclude all but the first file. Also see [1].

[1]: https://youtrack.jetbrains.com/issue/IDEA-305759
