### PR TITLE
fix: Prevent file dialog from reopening

### DIFF
--- a/src/main/kotlin/ui/App.kt
+++ b/src/main/kotlin/ui/App.kt
@@ -65,8 +65,14 @@ fun App(controller: WorkbenchController) {
     val scope = rememberCoroutineScope()
 
     fun loadResult() = scope.launch {
-        val path = controller.openResultDialog.awaitResult()
-        if (path != null) controller.openOrtResult(path.toFile())
+        val isNotLoadingFile = controller.ortModels.value.none {
+            it.state.value in listOf(OrtApiState.LOADING_RESULT, OrtApiState.PROCESSING_RESULT)
+        }
+
+        if (isNotLoadingFile) {
+            val path = controller.openResultDialog.awaitResult()
+            if (path != null) controller.openOrtResult(path.toFile())
+        }
     }
 
     OrtWorkbenchTheme(settings.theme) {


### PR DESCRIPTION
Fix the issue again that the file dialog could reopen when selecting the file with a double-click. This was originally fixed in f4c4160 by checking if another file is already loading before showing the dialog. The check was removed in 47d7455 and it also did not make sense anymore to do this check in `openResultDialog` because since 871c2c2 there can be more than one instance of `OrtModel`. Therefore reintroduce the check in the `loadResult` function which opens the file dialog.