### PR TITLE
deps: Update molecule to version 1.1.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
     alias(libs.plugins.compose)
     alias(libs.plugins.detekt)
     alias(libs.plugins.kotlin)
-    alias(libs.plugins.molecule)
     alias(libs.plugins.versionCatalogUpdate)
     alias(libs.plugins.versions)
 }
@@ -62,6 +61,7 @@ dependencies {
     implementation(libs.kotlinxCoroutinesSwing)
     implementation(libs.log4jApiToSlf4j)
     implementation(libs.logbackClassic)
+    implementation(libs.moleculeRuntime)
 
     detektPlugins(libs.detektFormatting)
     detektPlugins(libs.ortDetektRules)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,6 @@
 detektPlugin = "1.23.0"
 composePlugin = "1.4.1"
 kotlinPlugin = "1.8.20"
-moleculePlugin = "0.9.0"
 versionCatalogUpdatePlugin = "0.8.1"
 versionsPlugin = "0.47.0"
 
@@ -11,6 +10,7 @@ kotlinxCoroutines = "1.7.2"
 log4jApi = "2.20.0"
 log4jApiKotlin = "1.2.0"
 logbackImpl = "1.4.8"
+moleculeRuntime = "1.1.0"
 ort = "193f850e24"
 richtext = "0.17.0"
 
@@ -18,7 +18,6 @@ richtext = "0.17.0"
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detektPlugin" }
 compose = { id = "org.jetbrains.compose", version.ref = "composePlugin" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlinPlugin" }
-molecule = { id = "app.cash.molecule", version.ref = "moleculePlugin" }
 versionCatalogUpdate = { id = "nl.littlerobots.version-catalog-update", version.ref = "versionCatalogUpdatePlugin" }
 versions = { id = "com.github.ben-manes.versions", version.ref = "versionsPlugin" }
 
@@ -30,6 +29,7 @@ kotlinxCoroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-sw
 log4jApiKotlin = { module = "org.apache.logging.log4j:log4j-api-kotlin", version.ref = "log4jApiKotlin" }
 log4jApiToSlf4j = { module = "org.apache.logging.log4j:log4j-to-slf4j", version.ref = "log4jApi" }
 logbackClassic = { module = "ch.qos.logback:logback-classic", version.ref = "logbackImpl" }
+moleculeRuntime = { module = "app.cash.molecule:molecule-runtime", version.ref = "moleculeRuntime" }
 ortDetektRules = { module = "com.github.oss-review-toolkit.ort:detekt-rules", version.ref = "ort" }
 ortModel = { module = "com.github.oss-review-toolkit.ort:model", version.ref = "ort" }
 ortReporter = { module = "com.github.oss-review-toolkit.ort:reporter", version.ref = "ort" }

--- a/src/main/kotlin/lifecycle/MoleculeViewModel.kt
+++ b/src/main/kotlin/lifecycle/MoleculeViewModel.kt
@@ -2,7 +2,7 @@ package org.ossreviewtoolkit.workbench.lifecycle
 
 import androidx.compose.runtime.Composable
 
-import app.cash.molecule.RecompositionClock
+import app.cash.molecule.RecompositionMode
 import app.cash.molecule.launchMolecule
 
 import kotlinx.coroutines.CoroutineScope
@@ -32,7 +32,7 @@ abstract class MoleculeViewModel<EVENT, MODEL> : ViewModel() {
      * A [StateFlow] that emits new [MODEL]s on updates.
      */
     val model: StateFlow<MODEL> by lazy(LazyThreadSafetyMode.NONE) {
-        moleculeScope.launchMolecule(clock = RecompositionClock.Immediate) {
+        moleculeScope.launchMolecule(mode = RecompositionMode.Immediate) {
             composeModel(events)
         }
     }


### PR DESCRIPTION
The Molecule Gradle plugin cannot be applied to the same project as the JetBrains Compose Gradle plugin. Both plugins attempt to configure the Compose compiler plugin which is incompatible. So just add the molecule runtime dependency.