### PR TITLE
Use only resolved config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,6 @@ dependencies {
     implementation(compose.desktop.currentOs)
     implementation(libs.bundles.ort)
     implementation(libs.bundles.richtext)
-    implementation(libs.composeMaterialIconsExtendedDesktop)
     implementation(libs.jacksonModuleKotlin)
     implementation(libs.kotlinxCoroutinesSwing)
     implementation(libs.log4jApiToSlf4j)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,6 @@ versions = { id = "com.github.ben-manes.versions", version.ref = "versionsPlugin
 
 [libraries]
 detektFormatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detektPlugin" }
-composeMaterialIconsExtendedDesktop = { module = "org.jetbrains.compose.material:material-icons-extended-desktop", version.ref = "composePlugin" }
 jacksonModuleKotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 kotlinxCoroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinxCoroutines" }
 log4jApiKotlin = { module = "org.apache.logging.log4j:log4j-api-kotlin", version.ref = "log4jApiKotlin" }

--- a/src/main/kotlin/composables/Tooltip.kt
+++ b/src/main/kotlin/composables/Tooltip.kt
@@ -28,7 +28,7 @@ fun Tooltip(text: String) {
         enter = fadeIn(),
         exit = fadeOut()
     ) {
-        Box(modifier = Modifier.clip(RoundedCornerShape(percent = 50)), contentAlignment = Alignment.Center) {
+        Box(modifier = Modifier.clip(RoundedCornerShape(size = 8.dp)), contentAlignment = Alignment.Center) {
             Row(modifier = Modifier.background(MaterialTheme.colors.primaryVariant).padding(8.dp)) {
                 Text(text, style = MaterialTheme.typography.caption, color = MaterialTheme.colors.onPrimary)
             }

--- a/src/main/kotlin/ui/App.kt
+++ b/src/main/kotlin/ui/App.kt
@@ -139,6 +139,7 @@ fun MainLayout(controller: WorkbenchController, onLoadResult: () -> Unit) {
     val ortModelState = controller.ortModel.collectAsState()
     val ortModel = ortModelState.value ?: return
     val apiState by ortModel.state.collectAsState()
+    val scope = rememberCoroutineScope()
 
     val navController = ortModel.navController
 
@@ -147,6 +148,7 @@ fun MainLayout(controller: WorkbenchController, onLoadResult: () -> Unit) {
             val ortModels by controller.ortModels.collectAsState()
             val ortModelInfos by combine(ortModels.map { it.info }) { it.filterNotNull() }.collectAsState(emptyList())
             val selectedOrtModelInfo by ortModel.info.collectAsState()
+            val useOnlyResolvedConfiguration by ortModel.useOnlyResolvedConfiguration.collectAsState()
 
             TopBar(
                 selectedOrtModelInfo,
@@ -162,6 +164,10 @@ fun MainLayout(controller: WorkbenchController, onLoadResult: () -> Unit) {
                 Menu(
                     currentMenuItem,
                     apiState,
+                    useOnlyResolvedConfiguration = useOnlyResolvedConfiguration,
+                    onSwitchUseOnlyResolvedConfiguration = {
+                        scope.launch { ortModel.switchUseOnlyResolvedConfiguration() }
+                    },
                     onSelectMenuItem = { selectMenuItem(controller, ortModel, navController, it) }
                 )
 

--- a/src/main/kotlin/ui/Menu.kt
+++ b/src/main/kotlin/ui/Menu.kt
@@ -3,6 +3,9 @@
 package org.ossreviewtoolkit.workbench.ui
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.TooltipArea
+import androidx.compose.foundation.TooltipPlacement
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -19,6 +22,7 @@ import androidx.compose.material.Icon
 import androidx.compose.material.LocalContentAlpha
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
+import androidx.compose.material.Switch
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -33,12 +37,20 @@ import androidx.compose.ui.zIndex
 
 import org.ossreviewtoolkit.utils.ort.Environment
 import org.ossreviewtoolkit.workbench.composables.Preview
+import org.ossreviewtoolkit.workbench.composables.Tooltip
 import org.ossreviewtoolkit.workbench.composables.conditional
 import org.ossreviewtoolkit.workbench.composables.enumcase
 import org.ossreviewtoolkit.workbench.model.OrtApiState
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun Menu(currentItem: MenuItem?, apiState: OrtApiState, onSelectMenuItem: (MenuItem) -> Unit) {
+fun Menu(
+    currentItem: MenuItem?,
+    apiState: OrtApiState,
+    useOnlyResolvedConfiguration: Boolean,
+    onSwitchUseOnlyResolvedConfiguration: () -> Unit,
+    onSelectMenuItem: (MenuItem) -> Unit
+) {
     Surface(modifier = Modifier.fillMaxHeight().width(200.dp).zIndex(zIndex = 3f), elevation = 8.dp) {
         Column(
             modifier = Modifier.padding(vertical = 20.dp)
@@ -52,6 +64,43 @@ fun Menu(currentItem: MenuItem?, apiState: OrtApiState, onSelectMenuItem: (MenuI
                 MenuRow(MenuItem.VULNERABILITIES, currentItem, apiState) { onSelectMenuItem(MenuItem.VULNERABILITIES) }
 
                 Box(modifier = Modifier.weight(1f))
+
+                Divider()
+
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp, horizontal = 20.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "Use only resolved configuration",
+                        style = MaterialTheme.typography.h6,
+                        modifier = Modifier.weight(1f)
+                    )
+
+                    TooltipArea(
+                        tooltipPlacement = TooltipPlacement.ComponentRect(
+                            anchor = Alignment.TopCenter,
+                            alignment = Alignment.TopCenter
+                        ),
+                        tooltip = {
+                            Tooltip(
+                                """
+                                    Use only the resolved configuration from the ORT result and ignore the local ORT
+                                    config directory. This can be disabled to test local configuration changes, but be
+                                    aware that this can lead to inconsistent results when the ORT result was created
+                                    with different configuration.
+                                    Please note that this setting currently only affects package configurations and
+                                    resolutions.
+                                """.trimIndent()
+                            )
+                        }
+                    ) {
+                        Switch(
+                            checked = useOnlyResolvedConfiguration,
+                            onCheckedChange = { onSwitchUseOnlyResolvedConfiguration() }
+                        )
+                    }
+                }
 
                 Divider()
 
@@ -100,6 +149,6 @@ fun MenuRow(item: MenuItem, currentItem: MenuItem?, apiState: OrtApiState, onSel
 @Preview
 private fun MenuPreview() {
     Preview {
-        Menu(currentItem = MenuItem.SUMMARY, OrtApiState.READY) {}
+        Menu(currentItem = MenuItem.SUMMARY, OrtApiState.READY, true, {}, {})
     }
 }


### PR DESCRIPTION
Add an option to only use the resolved config from the ORT result file. Please see the commit messages for details.
