### PR TITLE
deps: Upgrade Kotlin to version 1.9.10

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 detektPlugin = "1.23.1"
 composePlugin = "1.5.1"
-kotlinPlugin = "1.9.0"
+kotlinPlugin = "1.9.10"
 versionCatalogUpdatePlugin = "0.8.1"
 versionsPlugin = "0.47.0"
 


### PR DESCRIPTION
See [1]. This is supported by Compose 1.5.1 now.

[1]: https://github.com/JetBrains/kotlin/releases/tag/v1.9.10