### PR TITLE
chore(Gradle): Remove the SW360 repository declaration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,16 +39,6 @@ repositories {
             includeGroup("org.gradle")
         }
     }
-
-    exclusiveContent {
-        forRepository {
-            maven("https://repo.eclipse.org/content/repositories/sw360-releases/")
-        }
-
-        filter {
-            includeGroup("org.eclipse.sw360")
-        }
-    }
 }
 
 dependencies {


### PR DESCRIPTION
This is not required anymore as SW360 get published to Maven Central now. Also see [1] which part of ORT 2.0.0.

[1]: https://github.com/oss-review-toolkit/ort/commit/bc3404ca95cd44b3db9640e9b9a638bf55e3d649