### PR TITLE
deps(Gradle): Upgrade Kotlin to version 1.9.20

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 detektPlugin = "1.23.3"
 composePlugin = "1.5.10"
-kotlinPlugin = "1.9.10"
+kotlinPlugin = "1.9.20"
 versionCatalogUpdatePlugin = "0.8.1"
 versionsPlugin = "0.49.0"
 


### PR DESCRIPTION
See [1].

[1]: https://blog.jetbrains.com/kotlin/2023/11/kotlin-1-9-20-released/