### PR TITLE
build(Gradle): Remove the `versionCatalogUpdate` plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
     alias(libs.plugins.compose)
     alias(libs.plugins.detekt)
     alias(libs.plugins.kotlin)
-    alias(libs.plugins.versionCatalogUpdate)
     alias(libs.plugins.versions)
 }
 
@@ -71,11 +70,6 @@ tasks.named<DependencyUpdatesTask>("dependencyUpdates").configure {
     rejectVersionIf {
         candidate.version.matches(nonFinalQualifiersRegex)
     }
-}
-
-versionCatalogUpdate {
-    // Keep the custom sorting / grouping.
-    sortByKey.set(false)
 }
 
 java {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,6 @@
 detektPlugin = "1.23.4"
 composePlugin = "1.5.11"
 kotlinPlugin = "1.9.20"
-versionCatalogUpdatePlugin = "0.8.2"
 versionsPlugin = "0.50.0"
 
 dataTableMaterial = "0.5.1"
@@ -19,7 +18,6 @@ richtext = "0.17.0"
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detektPlugin" }
 compose = { id = "org.jetbrains.compose", version.ref = "composePlugin" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlinPlugin" }
-versionCatalogUpdate = { id = "nl.littlerobots.version-catalog-update", version.ref = "versionCatalogUpdatePlugin" }
 versions = { id = "com.github.ben-manes.versions", version.ref = "versionsPlugin" }
 
 [libraries]


### PR DESCRIPTION
With dependencies being updated on GitHub via Renovate now, there is little reason to keep this plugin to do the same locally. Keep the plain `versions` plugin for now, however, as just checking for new versions locally might be useful.