### PR TITLE
refactor: Use FileKit for the `FileDialog`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     implementation(libs.bundles.ort)
     implementation(libs.bundles.richtext)
     implementation(libs.dataTableMaterial)
+    implementation(libs.fileKit)
     implementation(libs.jacksonModuleKotlin)
     implementation(libs.kotlinxCoroutinesSwing)
     implementation(libs.log4jApiKotlin)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ kotlinPlugin = "2.0.0"
 versionsPlugin = "0.51.0"
 
 dataTableMaterial = "0.5.1"
+fileKit = "0.7.0"
 jackson = "2.17.2"
 kotlinxCoroutines = "1.8.1"
 log4jApi = "2.23.1"
@@ -24,6 +25,7 @@ versions = { id = "com.github.ben-manes.versions", version.ref = "versionsPlugin
 [libraries]
 dataTableMaterial = { module = "com.seanproctor:data-table-material", version.ref = "dataTableMaterial" }
 detektFormatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detektPlugin" }
+fileKit = { module = "io.github.vinceglb:filekit-core", version.ref = "fileKit" }
 jacksonModuleKotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 kotlinxCoroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinxCoroutines" }
 log4jApiKotlin = { module = "org.apache.logging.log4j:log4j-api-kotlin", version.ref = "log4jApiKotlin" }


### PR DESCRIPTION
The fixes the file dialog to actually work on Linux with Wayland. Also see a similar discussion at [1].

For now, only the load dialog is implemented, as saving would require another callback anyway.

[1]: https://github.com/gradle/gradle-client/issues/10