### PR TITLE
build(gradle): Also run the Gradle build with Java 21

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,7 @@ org.gradle.configuration-cache = true
 org.gradle.kotlin.dsl.allWarningsAsErrors = true
 org.gradle.parallel = true
 
+# Keep this aligned with `toolchainVersion` in `gradle/gradle-daemon-jvm.properties`.
 javaLanguageVersion = 21
 
 kotlin.code.style = official

--- a/gradle/gradle-daemon-jvm.properties
+++ b/gradle/gradle-daemon-jvm.properties
@@ -1,0 +1,3 @@
+# Keep this aligned with `javaLanguageVersion` in `gradle.properties`.
+toolchainVersion = 21
+toolchainVendor = Adoptium


### PR DESCRIPTION
The build uses ORT's Detekt rules which have been compiled with Java 21 as of ORT version 35.0.0, so also the Gradle build needs to be run with Java 21. Configure the Gradle daemon accordingly.