### PR TITLE
build(gradle): Configure a toolchain provider for bootstrapping

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,4 +7,9 @@ pluginManagement {
     }
 }
 
+plugins {
+    // Gradle cannot access the version catalog from here, so hard-code the dependency.
+    id("org.gradle.toolchains.foojay-resolver-convention").version("0.10.0")
+}
+
 rootProject.name = "ort-workbench"


### PR DESCRIPTION
Allow to build the project on machines where no matching local toolchain is found by bootstrapping one from remote.